### PR TITLE
fix: enable legacy ssh kex for cpanel deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           port:         ${{ secrets.SSH_PORT }}
           password:     ${{ secrets.SSH_PASSWORD }}
           fingerprint:  ${{ secrets.SSH_FINGERPRINT }}
+          use_insecure_cipher: true # required for cPanel servers that only offer diffie-hellman-group-exchange key exchange
           debug: true
           script: |
             set -euo pipefail


### PR DESCRIPTION
## Summary
- allow the GitHub Actions SSH step to use legacy key exchange algorithms required by the cPanel host

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68c8769aca708327807d07e751b25e05