### PR TITLE
Configure backend CORS origins via ALLOWED_ORIGINS env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # --- Backend (FastAPI) ---
 DATABASE_URL=postgresql+asyncpg://postgres:password@localhost:5432/alnoor_db
 SECRET_KEY=change_me_jwt_secret
+ALLOWED_ORIGINS=http://localhost:3000
 SQUARE_ACCESS_TOKEN=your_square_access_token
 SQUARE_LOCATION_ID=your_square_location_id
 SQUARE_ENV=sandbox

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.routes import products, orders, auth, pos, contact, admin
@@ -6,9 +8,17 @@ from app.database import init_db, seed_if_empty
 app = FastAPI(title="Al Noor Farm API", version="0.1.0")
 
 # CORS (adjust origins for production)
+allowed_origins_env = os.getenv("ALLOWED_ORIGINS", "")
+if allowed_origins_env:
+    allowed_origins = [origin.strip() for origin in allowed_origins_env.split(",") if origin.strip()]
+    if not allowed_origins:
+        allowed_origins = ["*"]
+else:
+    allowed_origins = ["*"]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- read the `ALLOWED_ORIGINS` environment variable and pass the parsed list to FastAPI's CORS middleware
- document the new configuration in `.env.example`

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68c899ae49e08327a73d11837e947caf