### PR TITLE
fix: set pending status for unpaid orders

### DIFF
--- a/backend/app/routes/orders.py
+++ b/backend/app/routes/orders.py
@@ -53,7 +53,7 @@ async def create_order(
             )
         )
 
-    status_val = "paid"
+    status_val = "pending"
 
     # Optional Square payment (sandbox/production) if token and env configured
     token = getattr(payload, "payment_token", None)
@@ -91,7 +91,8 @@ async def create_order(
             if resp.status_code >= 300:
                 detail = data.get("errors") if isinstance(data, dict) else data
                 raise HTTPException(status_code=400, detail=f"Payment failed: {detail}")
-            status_val = "paid"
+            else:
+                status_val = "paid"
         except HTTPException:
             raise
         except Exception as e:  # If SDK call fails, surface error gracefully

--- a/backend/tests/test_orders_endpoints.py
+++ b/backend/tests/test_orders_endpoints.py
@@ -36,6 +36,7 @@ async def test_get_and_update_order_flow():
         assert resp.status_code == 201
         order = resp.json()
         order_id = order["id"]
+        assert order["status"] == "pending"
 
         # Admin token
         token = await get_token(ac)
@@ -48,6 +49,7 @@ async def test_get_and_update_order_flow():
         assert body["id"] == order_id
         assert body["total_amount"] >= 0
         assert isinstance(body["items"], list) and len(body["items"]) == 1
+        assert body["status"] == "pending"
 
         # Update status
         resp = await ac.put(


### PR DESCRIPTION
## Summary
- default newly created orders to a pending status until payment confirmation
- only mark orders as paid after a successful Square payment response
- adjust order endpoint tests to assert the pending status when no payment token is used

## Testing
- `PYTHONPATH=backend pytest backend/tests` *(fails: coverage threshold fail-under=80, total coverage ~53%)*

------
https://chatgpt.com/codex/tasks/task_e_68c899b18a348327ba79050d320b2bf8