### PR TITLE
Add POS checkout session dependency

### DIFF
--- a/backend/app/routes/pos.py
+++ b/backend/app/routes/pos.py
@@ -4,21 +4,27 @@ from typing import Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel, Field
 
 from app.schemas import OrderCreate, OrderOut
 from .orders import create_order
 from app.deps import get_current_user
+from app.database import get_session
 
 
 router = APIRouter()
 
 
 @router.post("/pos/checkout", response_model=OrderOut)
-async def pos_checkout(payload: OrderCreate, user: str = Depends(get_current_user)):
+async def pos_checkout(
+    payload: OrderCreate,
+    session: AsyncSession = Depends(get_session),
+    user: str = Depends(get_current_user),
+):
     # Force source to 'pos' and reuse order creation logic
     payload.source = "pos"
-    return await create_order(payload)  # type: ignore[arg-type]
+    return await create_order(payload, session)
 
 
 class TerminalCheckoutRequest(BaseModel):

--- a/backend/tests/test_pos_checkout.py
+++ b/backend/tests/test_pos_checkout.py
@@ -1,0 +1,43 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+from app.database import init_db, seed_if_empty
+
+
+async def get_token(ac: AsyncClient) -> str:
+    resp = await ac.post("/auth/login", json={"username": "admin", "password": "admin123"})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_pos_checkout_succeeds():
+    await init_db()
+    await seed_if_empty()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        token = await get_token(ac)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await ac.get("/products", headers=headers)
+        assert resp.status_code == 200
+        products = resp.json()
+        assert isinstance(products, list) and len(products) > 0
+        product_id = products[0]["id"]
+
+        resp = await ac.post(
+            "/pos/checkout",
+            headers=headers,
+            json={
+                "items": [{"product_id": product_id, "quantity": 1}],
+                "customer_name": "POS Tester",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["source"] == "pos"
+        assert body["total_amount"] > 0
+        assert isinstance(body["items"], list) and len(body["items"]) == 1
+        assert body["items"][0]["product_id"] == product_id


### PR DESCRIPTION
## Summary
- ensure the POS checkout endpoint injects an AsyncSession and hands it to the shared order creation logic
- add an async regression test that exercises the POS checkout flow end to end

## Testing
- PYTHONPATH=. pytest tests -q *(fails: coverage threshold 80% not met, overall coverage 53.33%)*

------
https://chatgpt.com/codex/tasks/task_e_68c899b2ec48832796039b77b5be396c