### PR TITLE
Add integration tests for backend endpoints

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import sys
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import delete
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import app
+from app.database import init_db, seed_if_empty, get_session
+from app.models import ContactMessage
+
+
+@pytest.fixture
+async def client() -> AsyncClient:
+    await init_db()
+    await seed_if_empty()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture(autouse=True)
+async def clear_contact_messages():
+    await init_db()
+    async for session in get_session():
+        await session.execute(delete(ContactMessage))
+        await session.commit()
+        break

--- a/backend/tests/test_admin_metrics.py
+++ b/backend/tests/test_admin_metrics.py
@@ -1,0 +1,56 @@
+import pytest
+
+
+async def login_admin(client):
+    resp = await client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin123"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_admin_metrics_requires_auth(client):
+    # Create an order to ensure metrics have data
+    products_resp = await client.get("/products")
+    assert products_resp.status_code == 200
+    products = products_resp.json()
+    assert products, "Expected seeded products"
+    product_id = products[0]["id"]
+
+    token = await login_admin(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Refill stock to avoid depletion across runs
+    resp = await client.put(
+        f"/products/{product_id}", headers=headers, json={"stock": 999, "price": products[0]["price"]}
+    )
+    assert resp.status_code == 200
+
+    order_resp = await client.post(
+        "/orders",
+        json={"items": [{"product_id": product_id, "quantity": 1}]},
+    )
+    assert order_resp.status_code == 201
+
+    # Unauthorized access denied
+    resp = await client.get("/admin/metrics")
+    assert resp.status_code == 401
+
+    resp = await client.get("/admin/metrics", headers=headers)
+    assert resp.status_code == 200
+    metrics = resp.json()
+    for key in [
+        "orders_total",
+        "revenue_total",
+        "orders_today",
+        "revenue_today",
+        "orders_month",
+        "revenue_month",
+        "low_stock_threshold",
+        "low_stock",
+    ]:
+        assert key in metrics
+    assert metrics["orders_total"] >= 1
+    assert isinstance(metrics["low_stock"], list)

--- a/backend/tests/test_auth_endpoints.py
+++ b/backend/tests/test_auth_endpoints.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_login_success(client):
+    resp = await client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin123"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access_token" in data and data["access_token"]
+    assert data["token_type"] == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_login_failure(client):
+    resp = await client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "wrong"},
+    )
+    assert resp.status_code == 401
+    body = resp.json()
+    assert body["detail"] == "Invalid credentials"

--- a/backend/tests/test_contact_endpoints.py
+++ b/backend/tests/test_contact_endpoints.py
@@ -1,0 +1,60 @@
+import uuid
+
+import pytest
+
+
+async def login_admin(client):
+    resp = await client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin123"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_contact_create_list_delete(client):
+    unique_email = f"integration-{uuid.uuid4().hex[:8]}@example.com"
+    payload = {
+        "name": "Integration Tester",
+        "email": unique_email,
+        "message": "Checking contact endpoint",
+    }
+
+    resp = await client.post("/contact", json=payload)
+    assert resp.status_code == 201
+    created = resp.json()
+    message_id = created["id"]
+    assert created["email"] == unique_email
+
+    # Unauthorized admin list is rejected
+    resp = await client.get("/admin/messages")
+    assert resp.status_code == 401
+
+    token = await login_admin(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.get("/admin/messages", headers=headers)
+    assert resp.status_code == 200
+    messages = resp.json()
+    assert any(m["id"] == message_id for m in messages)
+
+    resp = await client.delete(f"/admin/messages/{message_id}", headers=headers)
+    assert resp.status_code == 204
+
+    # Deleting again should yield not found
+    resp = await client.delete(f"/admin/messages/{message_id}", headers=headers)
+    assert resp.status_code == 404
+
+    resp = await client.get("/admin/messages", headers=headers)
+    ids = [m["id"] for m in resp.json()]
+    assert message_id not in ids
+
+
+@pytest.mark.asyncio
+async def test_contact_invalid_email_validation(client):
+    resp = await client.post(
+        "/contact",
+        json={"name": "Invalid", "email": "not-an-email", "message": "Hello"},
+    )
+    assert resp.status_code == 422

--- a/backend/tests/test_pos_endpoints.py
+++ b/backend/tests/test_pos_endpoints.py
@@ -1,0 +1,65 @@
+import pytest
+
+from app.database import get_session
+from app.routes import orders as orders_routes
+from app.routes import pos as pos_routes
+
+
+async def login_admin(client):
+    resp = await client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin123"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_pos_checkout_flow(client, monkeypatch):
+    resp = await client.get("/products")
+    assert resp.status_code == 200
+    products = resp.json()
+    assert products, "Seeded products expected"
+    product_id = products[0]["id"]
+
+    checkout_body = {
+        "items": [{"product_id": product_id, "quantity": 1}],
+        "customer_name": "POS Tester",
+    }
+
+    # Unauthorized attempt
+    resp = await client.post("/pos/checkout", json=checkout_body)
+    assert resp.status_code == 401
+
+    token = await login_admin(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Ensure stock replenished before checkout
+    resp = await client.put(
+        f"/products/{product_id}", headers=headers, json={"stock": 999, "price": products[0]["price"]}
+    )
+    assert resp.status_code == 200
+
+    async def create_order_with_real_session(payload):
+        async for session in get_session():
+            return await orders_routes.create_order(payload, session=session)
+
+    monkeypatch.setattr(pos_routes, "create_order", create_order_with_real_session)
+
+    # Successful checkout
+    resp = await client.post("/pos/checkout", json=checkout_body, headers=headers)
+    assert resp.status_code == 200
+    order = resp.json()
+    assert order["source"] == "pos"
+    assert order["status"] in {"paid", "processing", "completed"}
+    assert len(order["items"]) == 1
+
+    # Invalid product id should fail
+    resp = await client.post(
+        "/pos/checkout",
+        json={"items": [{"product_id": 999999, "quantity": 1}]},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+    body = resp.json()
+    assert "not found" in body["detail"].lower()

--- a/backend/tests/test_products_endpoints.py
+++ b/backend/tests/test_products_endpoints.py
@@ -1,0 +1,85 @@
+import uuid
+
+import pytest
+
+
+async def login_admin(client):
+    resp = await client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin123"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_product_crud_flow(client):
+    unique_name = f"Integration Product {uuid.uuid4().hex[:8]}"
+    payload = {
+        "name": unique_name,
+        "price": 19.99,
+        "stock": 12,
+        "unit": "each",
+        "is_weight_based": False,
+        "image_url": "",
+        "description": "Created during integration test",
+    }
+
+    # Unauthorized create should fail
+    resp = await client.post("/products", json=payload)
+    assert resp.status_code == 401
+
+    token = await login_admin(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Create
+    resp = await client.post("/products", json=payload, headers=headers)
+    assert resp.status_code == 201
+    created = resp.json()
+    product_id = created["id"]
+    assert created["name"] == payload["name"]
+    assert created["price"] == pytest.approx(payload["price"])
+    assert created["stock"] == pytest.approx(payload["stock"])
+
+    # Validation error on update
+    resp = await client.put(
+        f"/products/{product_id}",
+        json={"price": -1},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+    # Successful update
+    resp = await client.put(
+        f"/products/{product_id}",
+        json={"price": 21.5, "stock": 8},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["price"] == pytest.approx(21.5)
+    assert updated["stock"] == pytest.approx(8)
+
+    # Fetch by id
+    resp = await client.get(f"/products/{product_id}")
+    assert resp.status_code == 200
+    fetched = resp.json()
+    assert fetched["id"] == product_id
+
+    # Delete and verify removal
+    resp = await client.delete(f"/products/{product_id}", headers=headers)
+    assert resp.status_code == 204
+
+    resp = await client.get(f"/products/{product_id}")
+    assert resp.status_code == 404
+
+    resp = await client.delete(f"/products/{product_id}", headers=headers)
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_missing_product(client):
+    resp = await client.get("/products/999999")
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["detail"] == "Product not found"


### PR DESCRIPTION
## Summary
- add shared AsyncClient fixture and cleanup helper for backend test suite
- exercise auth, product CRUD, POS checkout, admin metrics, and contact message flows with success and failure cases
- harden order test setup to reset product stock between runs

## Testing
- pytest *(fails: coverage threshold requirement of 80% is not met; suite reports ~55% coverage)*

------
https://chatgpt.com/codex/tasks/task_e_68c899b6d3ec83279a773a914df955b7