### PR TITLE
feat: secure admin auth with http-only cookie

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -8,11 +8,13 @@ from app.utils.security import decode_token
 
 def get_bearer_token(request: Request) -> Optional[str]:
     auth = request.headers.get("Authorization")
-    if not auth:
-        return None
-    parts = auth.split()
-    if len(parts) == 2 and parts[0].lower() == "bearer":
-        return parts[1]
+    if auth:
+        parts = auth.split()
+        if len(parts) == 2 and parts[0].lower() == "bearer":
+            return parts[1]
+    cookie_token = request.cookies.get("alnoor_token")
+    if cookie_token:
+        return cookie_token
     return None
 
 

--- a/frontend/app/admin/login/page.tsx
+++ b/frontend/app/admin/login/page.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 import { useState } from "react";
 import { login } from "@/lib/api";
 import { useRouter } from "next/navigation";
@@ -9,19 +9,13 @@ export default function AdminLoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const params = null as any;
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setLoading(true);
     try {
-      const res = await login(username, password);
-      // Store token for future use (placeholder)
-      localStorage.setItem("alnoor_token", res.access_token);
-      // Also set a cookie so middleware can protect /admin routes
-      const maxAge = 60 * 60 * 24; // 1 day
-      document.cookie = `alnoor_token=${res.access_token}; Path=/; Max-Age=${maxAge}`;
+      await login(username, password);
       const next = (typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get('next') : null) || '/admin/products';
       const safeNext = next.startsWith('/') ? next : '/admin/products';
       router.push(safeNext);

--- a/frontend/app/admin/orders/page.tsx
+++ b/frontend/app/admin/orders/page.tsx
@@ -1,6 +1,6 @@
-﻿"use client";
+"use client";
 import { useEffect, useMemo, useState } from "react";
-import { listOrders, updateOrderStatus, type Order } from "@/lib/api";
+import { listOrders, updateOrderStatus, type Order, logout as logoutSession } from "@/lib/api";
 import Spinner from "@/components/Spinner";
 import { useToast } from "@/components/Toast";
 
@@ -12,6 +12,18 @@ export default function AdminOrdersPage() {
   const [fromDate, setFromDate] = useState("");
   const [toDate, setToDate] = useState("");
 
+  async function logoutAndRedirect(nextPath: string) {
+    try {
+      await logoutSession();
+    } catch (err) {
+      console.error("Failed to clear session", err);
+    } finally {
+      if (typeof window !== "undefined") {
+        window.location.href = `/admin/login?next=${encodeURIComponent(nextPath)}`;
+      }
+    }
+  }
+
   async function load() {
     setLoading(true);
     setError(null);
@@ -22,11 +34,7 @@ export default function AdminOrdersPage() {
       const msg = e?.message || "Failed to load orders";
       setError(msg);
       if (msg.includes('401')) {
-        try {
-          localStorage.removeItem('alnoor_token');
-          document.cookie = 'alnoor_token=; Path=/; Max-Age=0';
-          window.location.href = `/admin/login?next=${encodeURIComponent('/admin/orders')}`;
-        } catch {}
+        await logoutAndRedirect('/admin/orders');
       }
     } finally {
       setLoading(false);
@@ -44,11 +52,7 @@ export default function AdminOrdersPage() {
       const msg = e?.message || "Failed to update order";
       setError(msg);
       if (msg.includes('401')) {
-        try {
-          localStorage.removeItem('alnoor_token');
-          document.cookie = 'alnoor_token=; Path=/; Max-Age=0';
-          window.location.href = `/admin/login?next=${encodeURIComponent('/admin/orders')}`;
-        } catch {}
+        await logoutAndRedirect('/admin/orders');
       }
       toast.error(e.message || "Failed to update order");
     }

--- a/frontend/app/api/auth/login/route.ts
+++ b/frontend/app/api/auth/login/route.ts
@@ -1,0 +1,129 @@
+import { NextResponse } from "next/server";
+
+const COOKIE_NAME = "alnoor_token";
+const ONE_DAY_SECONDS = 60 * 60 * 24;
+
+function resolveBackendBase(): string {
+  const candidates = [
+    process.env.AUTH_BACKEND_URL,
+    process.env.API_BASE_URL,
+    process.env.NEXT_PUBLIC_API_BASE_URL,
+  ];
+  for (const candidate of candidates) {
+    if (candidate && !candidate.startsWith("/")) {
+      return candidate;
+    }
+  }
+  return process.env.AUTH_BACKEND_FALLBACK || "http://localhost:8000";
+}
+
+function joinUrl(base: string, path: string): string {
+  const normalizedBase = base.replace(/\/+$/, "");
+  const normalizedPath = path.replace(/^\/+/, "");
+  return `${normalizedBase}/${normalizedPath}`;
+}
+
+async function parseBackendError(res: Response): Promise<string> {
+  let message = `Authentication failed (${res.status})`;
+  try {
+    const text = await res.text();
+    if (text) {
+      try {
+        const data = JSON.parse(text);
+        const detail =
+          typeof data === "string"
+            ? data
+            : data?.detail || data?.error || data?.message;
+        if (typeof detail === "string" && detail.trim()) {
+          message = detail;
+        } else if (text.trim()) {
+          message = text.trim();
+        }
+      } catch {
+        if (text.trim()) {
+          message = text.trim();
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return message;
+}
+
+export async function POST(request: Request) {
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const username = String(body?.username || "").trim();
+  const password = String(body?.password || "").trim();
+  if (!username || !password) {
+    return NextResponse.json(
+      { error: "Username and password are required" },
+      { status: 400 }
+    );
+  }
+
+  const backendBase = resolveBackendBase();
+  if (!/^https?:\/\//i.test(backendBase)) {
+    return NextResponse.json(
+      { error: "Backend base URL must be absolute" },
+      { status: 500 }
+    );
+  }
+
+  let backendResponse: Response;
+  try {
+    backendResponse = await fetch(joinUrl(backendBase, "auth/login"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password }),
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Unable to reach authentication service" },
+      { status: 502 }
+    );
+  }
+
+  if (!backendResponse.ok) {
+    const message = await parseBackendError(backendResponse);
+    return NextResponse.json({ error: message }, { status: backendResponse.status });
+  }
+
+  let data: any;
+  try {
+    data = await backendResponse.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid authentication response" },
+      { status: 502 }
+    );
+  }
+
+  const token = String(data?.access_token || "");
+  if (!token) {
+    return NextResponse.json(
+      { error: "Authentication response missing token" },
+      { status: 502 }
+    );
+  }
+
+  const response = NextResponse.json({ success: true });
+  const domain = process.env.AUTH_COOKIE_DOMAIN?.trim();
+  response.cookies.set({
+    name: COOKIE_NAME,
+    value: token,
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: ONE_DAY_SECONDS,
+    path: "/",
+    ...(domain ? { domain } : {}),
+  });
+  return response;
+}

--- a/frontend/app/api/auth/logout/route.ts
+++ b/frontend/app/api/auth/logout/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+const COOKIE_NAME = "alnoor_token";
+
+export async function POST() {
+  const response = NextResponse.json({ success: true });
+  const domain = process.env.AUTH_COOKIE_DOMAIN?.trim();
+  response.cookies.set({
+    name: COOKIE_NAME,
+    value: "",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+    ...(domain ? { domain } : {}),
+  });
+  return response;
+}

--- a/frontend/app/api/auth/session/route.ts
+++ b/frontend/app/api/auth/session/route.ts
@@ -1,0 +1,11 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+const COOKIE_NAME = "alnoor_token";
+
+export async function GET() {
+  const token = cookies().get(COOKIE_NAME)?.value;
+  const response = NextResponse.json({ authenticated: Boolean(token) });
+  response.headers.set("Cache-Control", "no-store");
+  return response;
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -12,6 +12,40 @@ export type Product = {
 export const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
+async function buildError(
+  res: Response,
+  fallback: string
+): Promise<Error> {
+  let message = `${fallback}: ${res.status}`;
+  try {
+    const text = await res.text();
+    if (text) {
+      try {
+        const data = JSON.parse(text);
+        const detail =
+          typeof data === "string"
+            ? data
+            : data?.detail || data?.error || data?.message;
+        if (typeof detail === "string" && detail.trim()) {
+          message = detail;
+        } else if (text.trim()) {
+          message = text.trim();
+        }
+      } catch {
+        if (text.trim()) {
+          message = text.trim();
+        }
+      }
+    }
+  } catch {
+    // ignore body parse errors
+  }
+  if (res.status === 401 && !message.includes("401")) {
+    message = "401 Unauthorized";
+  }
+  return new Error(message);
+}
+
 export async function fetchProducts(): Promise<Product[]> {
   const res = await fetch(`${API_BASE}/products`, { cache: "no-store" });
   if (!res.ok) {
@@ -27,16 +61,15 @@ export async function fetchProduct(id: number): Promise<Product> {
 }
 
 export async function createProduct(input: Omit<Product, "id">): Promise<Product> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("alnoor_token") : null;
   const res = await fetch(`${API_BASE}/products`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
+    credentials: "include",
     body: JSON.stringify(input),
   });
-  if (!res.ok) throw new Error(`Failed to create product: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Failed to create product");
   return res.json();
 }
 
@@ -44,13 +77,31 @@ export async function createProduct(input: Omit<Product, "id">): Promise<Product
 export async function login(
   username: string,
   password: string
-): Promise<{ access_token: string; token_type: string }> {
-  const res = await fetch(`${API_BASE}/auth/login`, {
+): Promise<void> {
+  const res = await fetch(`/api/auth/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify({ username, password }),
   });
-  if (!res.ok) throw new Error(`Login failed: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Login failed");
+}
+
+export async function logout(): Promise<void> {
+  const res = await fetch(`/api/auth/logout`, {
+    method: "POST",
+    credentials: "include",
+  });
+  if (!res.ok) throw await buildError(res, "Logout failed");
+}
+
+export async function fetchSession(): Promise<{ authenticated: boolean }> {
+  const res = await fetch(`/api/auth/session`, {
+    method: "GET",
+    cache: "no-store",
+    credentials: "include",
+  });
+  if (!res.ok) throw await buildError(res, "Failed to fetch session");
   return res.json();
 }
 
@@ -91,18 +142,15 @@ export async function createOrder(input: {
 }
 
 export async function listOrders(params?: { startDate?: string; endDate?: string }): Promise<Order[]> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("alnoor_token") : null;
   const qs = params ? new URLSearchParams({
     ...(params.startDate ? { start_date: params.startDate } : {}),
     ...(params.endDate ? { end_date: params.endDate } : {}),
   }).toString() : "";
   const res = await fetch(`${API_BASE}/orders${qs ? `?${qs}` : ""}`, {
     cache: "no-store",
-    headers: {
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
+    credentials: "include",
   });
-  if (!res.ok) throw new Error(`Failed to list orders: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Failed to list orders");
   return res.json();
 }
 
@@ -110,16 +158,15 @@ export async function updateOrderStatus(
   id: number,
   status: string
 ): Promise<Order> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("alnoor_token") : null;
   const res = await fetch(`${API_BASE}/orders/${id}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
+    credentials: "include",
     body: JSON.stringify({ status }),
   });
-  if (!res.ok) throw new Error(`Failed to update order: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Failed to update order");
   return res.json();
 }
 
@@ -131,16 +178,15 @@ export async function createTerminalCheckout(args: {
   device_id?: string;
   reference_id?: string;
 }): Promise<TerminalCheckout> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("alnoor_token") : null;
   const res = await fetch(`${API_BASE}/pos/terminal/checkout`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
+    credentials: "include",
     body: JSON.stringify(args),
   });
-  if (!res.ok) throw new Error(`Terminal checkout failed: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Terminal checkout failed");
   return res.json();
 }
 
@@ -154,72 +200,60 @@ export type ContactMessage = {
 };
 
 export async function listMessages(): Promise<ContactMessage[]> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("alnoor_token") : null;
   const res = await fetch(`${API_BASE}/admin/messages`, {
-    headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}) },
     cache: "no-store",
+    credentials: "include",
   });
-  if (!res.ok) throw new Error(`Failed to list messages: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Failed to list messages");
   return res.json();
 }
 
 export async function deleteMessage(id: number): Promise<void> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("alnoor_token") : null;
   const res = await fetch(`${API_BASE}/admin/messages/${id}`, {
     method: "DELETE",
-    headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+    credentials: "include",
   });
-  if (!res.ok) throw new Error(`Failed to delete message: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Failed to delete message");
 }
 
 export async function pollTerminalCheckout(id: string): Promise<TerminalCheckout> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("alnoor_token") : null;
   const res = await fetch(`${API_BASE}/pos/terminal/checkout/${id}`, {
-    headers: {
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
     cache: "no-store",
+    credentials: "include",
   });
-  if (!res.ok) throw new Error(`Poll failed: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Poll failed");
   return res.json();
 }
 
 export async function getOrder(id: number): Promise<Order> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("alnoor_token") : null;
   const res = await fetch(`${API_BASE}/orders/${id}`, {
     cache: "no-store",
-    headers: {
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
+    credentials: "include",
   });
-  if (!res.ok) throw new Error(`Failed to get order: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Failed to get order");
   return res.json();
 }
 
 export async function deleteProduct(id: number): Promise<void> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("alnoor_token") : null;
   const res = await fetch(`${API_BASE}/products/${id}`, {
     method: "DELETE",
-    headers: {
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
+    credentials: "include",
   });
-  if (!res.ok) throw new Error(`Failed to delete product: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Failed to delete product");
 }
 
 export async function updateProduct(
   id: number,
   input: Partial<Omit<Product, "id">>
 ): Promise<Product> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("alnoor_token") : null;
   const res = await fetch(`${API_BASE}/products/${id}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
+    credentials: "include",
     body: JSON.stringify(input),
   });
-  if (!res.ok) throw new Error(`Failed to update product: ${res.status}`);
+  if (!res.ok) throw await buildError(res, "Failed to update product");
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add Next.js API auth routes that proxy login/logout and manage an HttpOnly cookie
- update lib API helpers and admin UI to rely on server-managed session checks instead of localStorage
- allow the backend auth dependency to read the session token from cookies for compatibility

## Testing
- NODE_ENV=development CI=true npm test -- --watch=false
- PYTHONPATH=backend pytest backend *(fails: coverage below configured 80% threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68c899b477e083279e33afed3782abec