### PR TITLE
Fix admin redirects and error login guidance

### DIFF
--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,22 +1,43 @@
 "use client";
-import { useEffect } from 'react';
+import { useEffect } from "react";
 
-export default function GlobalError({ error, reset }: { error: Error & { digest?: string }, reset: () => void }) {
-  useEffect(() => {
-    // Optionally report error to an APM service
-    // console.error(error);
-  }, [error]);
+export default function GlobalError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    useEffect(() => {
+        // Optionally report error to an APM service
+        // console.error(error);
+    }, [error]);
 
-  return (
-    <html>
-      <body>
-        <div className="max-w-2xl mx-auto p-6 text-center">
-          <h1 className="text-2xl font-semibold mb-2">Something went wrong</h1>
-          <p className="text-slate-600 mb-4">An unexpected error occurred. Please try again.</p>
-          <button onClick={() => reset()} className="text-blue-700 hover:underline">Reload</button>
-        </div>
-      </body>
-    </html>
-  );
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+    const loginHref = `${basePath}/admin/login`;
+
+    return (
+        <html>
+            <body>
+                <div className="max-w-2xl mx-auto p-6 text-center">
+                    <h1 className="text-2xl font-semibold mb-2">Something went wrong</h1>
+                    <p className="text-slate-600 mb-4">
+                        An unexpected error occurred. Please try again.
+                    </p>
+                    <p className="text-slate-600 mb-6">
+                        If the issue persists, please
+                        {" "}
+                        <a className="text-blue-700 hover:underline" href={loginHref}>
+                            log in
+                        </a>{" "}
+                        to continue.
+                    </p>
+                    <button className="text-blue-700 hover:underline" onClick={() => reset()}>
+                        Reload
+                    </button>
+                </div>
+            </body>
+        </html>
+    );
 }
 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,42 +1,68 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-export function middleware(req: NextRequest) {
-  const { pathname } = req.nextUrl;
-  const bp = process.env.NEXT_PUBLIC_BASE_PATH || "";
-
-  if (pathname.startsWith("/admin") && pathname !== "/admin/login") {
-    const token = req.cookies.get("alnoor_token")?.value;
-    if (!token) {
-      const url = req.nextUrl.clone();
-      url.pathname = "/admin/login";
-      url.searchParams.set("next", pathname);
-      return NextResponse.redirect(url);
+function resolveNextParam(req: NextRequest): string {
+    const existing = req.nextUrl.searchParams.get("next");
+    if (existing && existing.trim().length > 0) {
+        return existing;
     }
-  }
 
-  // Short path helpers
-  if (pathname === "/store") {
-    const url = req.nextUrl.clone();
-    url.pathname = `${bp}/products`;
-    return NextResponse.redirect(url);
-  }
-  if (pathname === "/pos") {
-    const url = req.nextUrl.clone();
-    url.pathname = `${bp}/admin/pos`;
-    return NextResponse.redirect(url);
-  }
-  if (pathname === "/admin") {
+    const candidate = req.nextUrl.clone();
+    candidate.searchParams.delete("next");
+    const fallback = `${candidate.pathname}${candidate.search}`;
+
+    return fallback || "/";
+}
+
+function buildLoginRedirectUrl(req: NextRequest, basePath: string) {
+    const loginUrl = req.nextUrl.clone();
+    loginUrl.pathname = `${basePath}/admin/login`;
+    loginUrl.search = "";
+    loginUrl.searchParams.set("next", resolveNextParam(req));
+
+    return loginUrl;
+}
+
+export function middleware(req: NextRequest) {
+    const { pathname } = req.nextUrl;
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
     const token = req.cookies.get("alnoor_token")?.value;
-    const url = req.nextUrl.clone();
-    url.pathname = token ? `${bp}/admin/dashboard` : `${bp}/admin/login`;
-    return NextResponse.redirect(url);
-  }
 
-  return NextResponse.next();
+    if (
+        pathname.startsWith("/admin") &&
+        pathname !== "/admin/login" &&
+        pathname !== "/admin" &&
+        !token
+    ) {
+        return NextResponse.redirect(buildLoginRedirectUrl(req, basePath));
+    }
+
+    if (pathname === "/admin") {
+        if (token) {
+            const url = req.nextUrl.clone();
+            url.pathname = `${basePath}/admin/dashboard`;
+            return NextResponse.redirect(url);
+        }
+
+        return NextResponse.redirect(buildLoginRedirectUrl(req, basePath));
+    }
+
+    // Short path helpers
+    if (pathname === "/store") {
+        const url = req.nextUrl.clone();
+        url.pathname = `${basePath}/products`;
+        return NextResponse.redirect(url);
+    }
+    if (pathname === "/pos") {
+        const url = req.nextUrl.clone();
+        url.pathname = `${basePath}/admin/pos`;
+        return NextResponse.redirect(url);
+    }
+
+    return NextResponse.next();
 }
 
 export const config = {
-  matcher: ["/admin/:path*", "/store", "/pos", "/admin"],
+    matcher: ["/admin/:path*", "/store", "/pos", "/admin"],
 };
 


### PR DESCRIPTION
## Summary
- add a login call-to-action to the global error screen
- preserve the `next` parameter when middleware redirects unauthenticated admin requests

## Testing
- NODE_ENV=test npm test -- --runTestsByPath __tests__/navbar.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c8a0adced88327bd59dda0a8248ea9