### PR TITLE
feat: add monitoring helpers for health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Copy `.env.example` to `.env` and adjust:
 - `NEXT_PUBLIC_API_BASE_URL=https://alnoorfarm716.com/api` (or your API location)
 - Optional:
   - `NEXT_PUBLIC_SQUARE_APP_ID`, `NEXT_PUBLIC_SQUARE_LOCATION_ID`, `NEXT_PUBLIC_SQUARE_ENV`
+  - `HOSTING_MONITOR_PING_URL` (optional URL that receives a GET when `/__health` is hit)
 
 #### Example environment variables (Python app)
 - `DATABASE_URL` (e.g., `postgresql+asyncpg://user:pass@host:5432/db`)
@@ -80,6 +81,14 @@ Copy `.env.example` to `.env` and adjust:
 - `ADMIN_USERNAME`, `ADMIN_PASSWORD`
 - Optional Square: `SQUARE_ACCESS_TOKEN`, `SQUARE_LOCATION_ID`, `SQUARE_ENV`
 - Optional SMTP: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_TLS`, `CONTACT_TO`
+
+### Health checks & monitoring
+- Frontend custom server exposes `GET /__health` for cPanel monitoring. When
+  `HOSTING_MONITOR_PING_URL` is set the server pings that URL (GET, 2-second
+  timeout) each time the health endpoint is invoked.
+- Backend FastAPI app exposes `GET /health` returning `{ "status": "ok" }`.
+- Run `python scripts/monitor_health.py --once` to verify both endpoints locally
+  or leave it running to poll them at regular intervals (`--interval 30`).
 
 ### Notes
 - DB and JWT verification are stubs. Replace in‑memory stores with Postgres via SQLAlchemy/SQLModel and real JWT as you progress.

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,3 +8,17 @@ Endpoints (starter):
 - `GET /` → welcome message
 - `GET /health` → { status: "ok" }
 
+### Health check usage
+
+The `/health` endpoint is intended for uptime monitors and load balancers. It
+returns HTTP 200 with a JSON body when the application and dependencies are
+ready to serve traffic.
+
+```bash
+curl -sSf http://localhost:8000/health
+# {"status":"ok"}
+```
+
+Configure your infrastructure monitors to alert if the request returns a
+non-200 status or times out.
+

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,26 +1,76 @@
 /* Minimal Next.js custom server for cPanel Node app */
-const { createServer } = require('http');
+const { createServer, request: httpRequest } = require('http');
+const { request: httpsRequest } = require('https');
 const { parse } = require('url');
 const next = require('next');
 
 const dev = process.env.NODE_ENV !== 'production';
+const monitorPingUrl = process.env.HOSTING_MONITOR_PING_URL;
 const app = next({ dev });
 const handle = app.getRequestHandler();
 
-app.prepare().then(() => {
-  const server = createServer((req, res) => {
-    const parsedUrl = parse(req.url, true);
-    if (parsedUrl.pathname === '/__health') {
-      res.statusCode = 200;
-      res.setHeader('Content-Type', 'text/plain');
-      res.end('ok');
-      return;
+function logMonitorError(error) {
+    if (process.env.NODE_ENV !== 'production') {
+        const detail = error instanceof Error ? error.message : String(error);
+        console.warn('[monitor] ping failed:', detail);
     }
-    handle(req, res, parsedUrl);
-  });
-  const port = process.env.PORT || 3000;
-  server.listen(port, (err) => {
-    if (err) throw err;
-    console.log(`> Next.js ready on http://localhost:${port}`);
-  });
+}
+
+function notifyHostingMonitor() {
+    if (!monitorPingUrl) {
+        return;
+    }
+
+    try {
+        const target = new URL(monitorPingUrl);
+        const client = target.protocol === 'https:' ? httpsRequest : httpRequest;
+        const requestOptions = {
+            method: 'GET',
+            hostname: target.hostname,
+            port: target.port || (target.protocol === 'https:' ? 443 : 80),
+            path: `${target.pathname}${target.search}`,
+            timeout: 2000,
+            headers: {
+                'User-Agent': 'alnoor-monitor/1.0',
+            },
+        };
+
+        const pingRequest = client(requestOptions, (monitorResponse) => {
+            monitorResponse.resume();
+        });
+
+        pingRequest.on('timeout', () => {
+            pingRequest.destroy(new Error('Request timeout'));
+        });
+        pingRequest.on('error', logMonitorError);
+        pingRequest.end();
+    } catch (error) {
+        logMonitorError(error);
+    }
+}
+
+app.prepare().then(() => {
+    const server = createServer((req, res) => {
+        const parsedUrl = parse(req.url, true);
+
+        if (parsedUrl.pathname === '/__health') {
+            res.statusCode = 200;
+            res.setHeader('Content-Type', 'text/plain');
+            if (req.method === 'HEAD') {
+                res.end();
+            } else {
+                res.end('ok');
+            }
+            notifyHostingMonitor();
+            return;
+        }
+
+        handle(req, res, parsedUrl);
+    });
+
+    const port = process.env.PORT || 3000;
+    server.listen(port, (err) => {
+        if (err) throw err;
+        console.log(`> Next.js ready on http://localhost:${port}`);
+    });
 });

--- a/scripts/monitor_health.py
+++ b/scripts/monitor_health.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Simple uptime monitor for the frontend and backend health endpoints."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from datetime import datetime
+from collections.abc import Sequence
+from urllib import error, request
+
+
+DEFAULT_FRONTEND_URL = "http://localhost:3000/__health"
+DEFAULT_BACKEND_URL = "http://localhost:8000/health"
+
+
+def fetch_status(url: str, timeout: float) -> tuple[bool, int | None, str]:
+    """Return a tuple with success flag, HTTP status, and optional detail."""
+
+    try:
+        with request.urlopen(url, timeout=timeout) as response:  # nosec B310
+            status_code = response.status
+            body = response.read(512).decode("utf-8", "replace")
+        return status_code == 200, status_code, body.strip()
+    except error.HTTPError as http_error:
+        detail = http_error.read().decode("utf-8", "replace")
+        return False, http_error.code, detail.strip()
+    except Exception as exc:  # pylint: disable=broad-except
+        return False, None, str(exc)
+
+
+def monitor(
+    targets: Sequence[tuple[str, str]],
+    interval: float,
+    timeout: float,
+    once: bool,
+) -> bool:
+    """Poll each target and return True when every check passes."""
+
+    overall_ok = True
+    while True:
+        timestamp = datetime.now().isoformat(timespec="seconds")
+        for name, url in targets:
+            is_ok, status_code, detail = fetch_status(url, timeout)
+            status_text = str(status_code) if status_code is not None else "-"
+            result = "OK" if is_ok else "FAIL"
+            print(f"[{timestamp}] {name.upper():8} {result:4} ({status_text}) {url}")
+            if not is_ok and detail:
+                print(f"    {detail[:200]}")
+            overall_ok = overall_ok and is_ok
+        if once:
+            return overall_ok
+        try:
+            time.sleep(interval)
+        except KeyboardInterrupt:
+            print("\nInterrupted. Exiting monitor loop.")
+            return overall_ok
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Poll the frontend /__health and backend /health endpoints and report uptime."
+        )
+    )
+    parser.add_argument(
+        "--frontend",
+        default=DEFAULT_FRONTEND_URL,
+        help="Frontend health check URL (set empty string to skip).",
+    )
+    parser.add_argument(
+        "--backend",
+        default=DEFAULT_BACKEND_URL,
+        help="Backend health check URL (set empty string to skip).",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=60.0,
+        help="Seconds to wait between checks (default: 60).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Seconds to wait for each response (default: 5).",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run a single round of checks and exit with a failing status if any fail.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    targets: list[tuple[str, str]] = []
+    if args.frontend:
+        targets.append(("frontend", args.frontend))
+    if args.backend:
+        targets.append(("backend", args.backend))
+
+    if not targets:
+        print("No endpoints provided. Use --frontend or --backend.")
+        return 1
+
+    all_ok = monitor(targets, args.interval, args.timeout, args.once)
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add optional hosting monitor ping to the Next.js `/__health` endpoint and accept HEAD requests
- document how to consume the FastAPI `/health` endpoint and expose new monitoring guidance
- provide a reusable `scripts/monitor_health.py` helper to poll health checks during uptime monitoring

## Testing
- pytest tests/test_health.py *(fails: repository lacks async plugin/coverage target in default config)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a0ae8d948327a25feafbfef8cded