### PR TITLE
feat: add brand typography styling

### DIFF
--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -9,7 +9,7 @@ export default function ContactPage() {
   const mapSrc = `https://www.google.com/maps?q=${encodeURIComponent(address)}&output=embed`;
   return (
     <section className="grid gap-6">
-      <h1 className="text-2xl font-semibold">Contact</h1>
+      <h1 className="heading text-3xl sm:text-4xl">Contact</h1>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
@@ -36,26 +36,26 @@ export default function ContactPage() {
         </div>
         <div className="grid gap-3">
           <div className="border rounded p-4">
-            <h2 className="font-medium mb-2">Address</h2>
-            <p className="text-slate-700">{address}</p>
-            <a className="text-blue-700 hover:underline text-sm" href={`https://maps.google.com/?q=${encodeURIComponent(address)}`} target="_blank" rel="noopener">Open in Google Maps</a>
+            <h2 className="font-heading text-brand text-xl mb-2">Address</h2>
+            <p className="text-brand/80">{address}</p>
+            <a className="text-brand hover:text-brand-dark hover:underline text-sm" href={`https://maps.google.com/?q=${encodeURIComponent(address)}`} target="_blank" rel="noopener">Open in Google Maps</a>
           </div>
           <div className="border rounded p-4">
-            <h2 className="font-medium mb-2">Phone</h2>
-            <p className="text-slate-700">
-              <a className="hover:underline" href="tel:+17165241717">716-524-1717</a> (calls) •
-              <a className="hover:underline ml-1" href="https://wa.me/17165241717" target="_blank" rel="noopener">WhatsApp</a>
+            <h2 className="font-heading text-brand text-xl mb-2">Phone</h2>
+            <p className="text-brand/80">
+              <a className="text-brand hover:text-brand-dark hover:underline" href="tel:+17165241717">716-524-1717</a> (calls) •
+              <a className="text-brand hover:text-brand-dark hover:underline ml-1" href="https://wa.me/17165241717" target="_blank" rel="noopener">WhatsApp</a>
             </p>
           </div>
           <div className="border rounded p-4">
-            <h2 className="font-medium mb-2">Facebook</h2>
-            <a className="text-blue-700 hover:underline" href="https://www.facebook.com/profile.php?id=100093040494987" target="_blank" rel="noopener">Follow us on Facebook</a>
+            <h2 className="font-heading text-brand text-xl mb-2">Facebook</h2>
+            <a className="text-brand hover:text-brand-dark hover:underline" href="https://www.facebook.com/profile.php?id=100093040494987" target="_blank" rel="noopener">Follow us on Facebook</a>
           </div>
         </div>
       </div>
 
       <div className="border rounded p-4 max-w-xl">
-        <h2 className="font-medium mb-3">Send a message</h2>
+        <h2 className="font-heading text-brand text-xl mb-3">Send a message</h2>
         <ContactForm />
       </div>
     </section>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,11 +1,26 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-html, body { height: 100%; }
-
 @layer base {
+  html, body {
+    height: 100%;
+    @apply font-sans text-slate-800 bg-white;
+  }
+
   a, button { @apply transition-colors duration-150; }
-  input, select, textarea { @apply focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-1; }
-  a:focus-visible, button:focus-visible { @apply outline-none ring-2 ring-emerald-500 ring-offset-2; }
+  input, select, textarea { @apply focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-1; }
+  a:focus-visible, button:focus-visible { @apply outline-none ring-2 ring-brand ring-offset-2; }
+}
+
+@layer components {
+  .heading {
+    @apply font-heading text-brand tracking-tight;
+  }
+
+  .subheading {
+    @apply font-heading text-brand/80 uppercase tracking-wide text-xs;
+  }
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,14 +12,14 @@ export default function Home() {
         className="mx-auto mb-6 h-auto w-auto"
         priority
       />
-      <h1 className="text-3xl font-semibold mb-2">Al Noor Farm</h1>
-      <p className="text-slate-600 mb-6">
+      <h1 className="heading text-4xl mb-2 sm:text-5xl">Al Noor Farm</h1>
+      <p className="text-brand/80 mb-6 max-w-lg mx-auto">
         Browse products, manage inventory, and run POS.
       </p>
       <div className="flex gap-4 justify-center">
-        <Link className="text-blue-600 hover:underline" href="/products">Store</Link>
-        <Link className="text-blue-600 hover:underline" href="/admin/login">Admin</Link>
-        <Link className="text-blue-600 hover:underline" href="/admin/pos">POS</Link>
+        <Link className="text-brand hover:text-brand-dark hover:underline font-medium" href="/products">Store</Link>
+        <Link className="text-brand hover:text-brand-dark hover:underline font-medium" href="/admin/login">Admin</Link>
+        <Link className="text-brand hover:text-brand-dark hover:underline font-medium" href="/admin/pos">POS</Link>
       </div>
     </div>
   );

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,18 +1,20 @@
 export default function Footer() {
   return (
     <footer className="border-t mt-8">
-      <div className="max-w-5xl mx-auto px-6 py-6 text-sm text-slate-600 grid gap-2 sm:flex sm:items-center sm:justify-between">
-        <div>© {new Date().getFullYear()} Al Noor Farm</div>
+      <div className="max-w-5xl mx-auto px-6 py-6 text-sm text-brand/80 grid gap-2 sm:flex sm:items-center sm:justify-between">
+        <div>
+          © {new Date().getFullYear()} <span className="font-heading text-brand">Al Noor Farm</span>
+        </div>
         <div className="flex items-center gap-3 flex-wrap">
-          <a className="hover:underline" href="/products">Store</a>
+          <a className="text-brand hover:text-brand-dark hover:underline" href="/products">Store</a>
           <span className="hidden sm:inline">•</span>
-          <a className="hover:underline" href="/admin/login">Admin</a>
+          <a className="text-brand hover:text-brand-dark hover:underline" href="/admin/login">Admin</a>
           <span className="hidden sm:inline">•</span>
-          <a className="hover:underline" href="tel:+17165241717">Call 716-524-1717</a>
+          <a className="text-brand hover:text-brand-dark hover:underline" href="tel:+17165241717">Call 716-524-1717</a>
           <span className="hidden sm:inline">•</span>
-          <a className="hover:underline" href="https://wa.me/17165241717" target="_blank" rel="noopener">WhatsApp</a>
+          <a className="text-brand hover:text-brand-dark hover:underline" href="https://wa.me/17165241717" target="_blank" rel="noopener">WhatsApp</a>
           <span className="hidden sm:inline">•</span>
-          <a className="hover:underline" href="https://www.facebook.com/profile.php?id=100093040494987" target="_blank" rel="noopener">Facebook</a>
+          <a className="text-brand hover:text-brand-dark hover:underline" href="https://www.facebook.com/profile.php?id=100093040494987" target="_blank" rel="noopener">Facebook</a>
         </div>
       </div>
     </footer>

--- a/frontend/components/Greeting.tsx
+++ b/frontend/components/Greeting.tsx
@@ -1,5 +1,5 @@
 "use client";
 export default function Greeting({ name = "World" }: { name?: string }) {
-  return <h1>Hello, {name}!</h1>;
+  return <h1 className="heading text-2xl">Hello, {name}!</h1>;
 }
 

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -44,34 +44,34 @@ export default function Navbar() {
         <div className="flex items-center gap-3">
           <Link href="/" className="flex items-center gap-2 hover:opacity-80">
             <Image src="/alnoorlogo.png" alt="Al Noor" width={24} height={24} />
-            <span className="font-semibold">Al Noor</span>
+            <span className="font-heading text-brand text-lg leading-none">Al Noor</span>
           </Link>
-          <Link href="/products" className="text-slate-700 hover:underline">Products</Link>
-          <Link href="/contact" className="text-slate-700 hover:underline">Contact</Link>
-          <Link href="/checkout" className="text-slate-700 hover:underline">Checkout</Link>
+          <Link href="/products" className="text-brand hover:text-brand-dark hover:underline">Products</Link>
+          <Link href="/contact" className="text-brand hover:text-brand-dark hover:underline">Contact</Link>
+          <Link href="/checkout" className="text-brand hover:text-brand-dark hover:underline">Checkout</Link>
           {hasToken ? (
             <>
-              <Link href="/admin/dashboard" className="text-slate-700 hover:underline">Dashboard</Link>
-              <Link href="/admin/products" className="text-slate-700 hover:underline">Admin Products</Link>
-              <Link href="/admin/orders" className="text-slate-700 hover:underline">Orders</Link>
-              <Link href="/admin/pos" className="text-slate-700 hover:underline">POS</Link>
-              <Link href="/admin/messages" className="text-slate-700 hover:underline">Messages</Link>
-              <Link href="/admin/settings" className="text-slate-700 hover:underline">Settings</Link>
+              <Link href="/admin/dashboard" className="text-brand hover:text-brand-dark hover:underline">Dashboard</Link>
+              <Link href="/admin/products" className="text-brand hover:text-brand-dark hover:underline">Admin Products</Link>
+              <Link href="/admin/orders" className="text-brand hover:text-brand-dark hover:underline">Orders</Link>
+              <Link href="/admin/pos" className="text-brand hover:text-brand-dark hover:underline">POS</Link>
+              <Link href="/admin/messages" className="text-brand hover:text-brand-dark hover:underline">Messages</Link>
+              <Link href="/admin/settings" className="text-brand hover:text-brand-dark hover:underline">Settings</Link>
             </>
           ) : (
-            <Link href="/admin/login" className="text-slate-700 hover:underline">Admin</Link>
+            <Link href="/admin/login" className="text-brand hover:text-brand-dark hover:underline">Admin</Link>
           )}
         </div>
         <div className="flex items-center gap-4">
-          <Link href="/cart" className="relative hover:underline">
+          <Link href="/cart" className="relative text-brand hover:text-brand-dark hover:underline">
             Cart
-            <span className="ml-1 inline-flex items-center justify-center text-xs rounded-full bg-emerald-600 text-white px-2 py-0.5">
+            <span className="ml-1 inline-flex items-center justify-center text-xs rounded-full bg-brand text-white px-2 py-0.5">
               {count.toFixed(0)}
             </span>
           </Link>
-          <div className="text-sm text-slate-600 hidden sm:block">${total.toFixed(2)}</div>
+          <div className="text-sm text-brand hidden sm:block font-heading">${total.toFixed(2)}</div>
           {hasToken && (
-            <button onClick={logout} className="text-slate-600 hover:underline text-sm">Logout</button>
+            <button onClick={logout} className="text-brand hover:text-brand-dark hover:underline text-sm">Logout</button>
           )}
         </div>
       </nav>

--- a/frontend/components/contact/ContactForm.tsx
+++ b/frontend/components/contact/ContactForm.tsx
@@ -33,27 +33,27 @@ export default function ContactForm() {
   return (
     <form onSubmit={onSubmit} className="grid gap-3" aria-live="polite">
       <div>
-        <label className="block text-sm text-slate-600" htmlFor="cname">Name</label>
+        <label className="block text-sm font-heading text-brand" htmlFor="cname">Name</label>
         <input id="cname" className="border rounded px-2 py-1 w-full" value={name} onChange={(e)=> setName(e.target.value)} placeholder="Your name" />
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
-          <label className="block text-sm text-slate-600" htmlFor="cemail">Email</label>
+          <label className="block text-sm font-heading text-brand" htmlFor="cemail">Email</label>
           <input id="cemail" type="email" className="border rounded px-2 py-1 w-full" value={email} onChange={(e)=> setEmail(e.target.value)} placeholder="you@example.com" />
         </div>
         <div>
-          <label className="block text-sm text-slate-600" htmlFor="cphone">Phone</label>
+          <label className="block text-sm font-heading text-brand" htmlFor="cphone">Phone</label>
           <input id="cphone" className="border rounded px-2 py-1 w-full" value={phone} onChange={(e)=> setPhone(e.target.value)} placeholder="(optional)" />
         </div>
       </div>
       <div>
-        <label className="block text-sm text-slate-600" htmlFor="cmsg">Message</label>
+        <label className="block text-sm font-heading text-brand" htmlFor="cmsg">Message</label>
         <textarea id="cmsg" className="border rounded px-2 py-1 w-full" rows={4} value={message} onChange={(e)=> setMessage(e.target.value)} placeholder="How can we help?" required />
       </div>
-      <button type="submit" className="bg-emerald-600 text-white px-3 py-1 rounded hover:bg-emerald-700 disabled:opacity-60" disabled={loading} aria-busy={loading}>
+      <button type="submit" className="bg-brand text-white px-3 py-1 rounded hover:bg-brand-dark disabled:opacity-60" disabled={loading} aria-busy={loading}>
         {loading ? "Sending..." : "Send"}
       </button>
-      {status && (<div className="text-sm text-slate-700">{status}</div>)}
+      {status && (<div className="text-sm text-brand">{status}</div>)}
     </form>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,5 @@
+const defaultTheme = require("tailwindcss/defaultTheme");
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
@@ -5,7 +7,20 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: "#2b5b2b",
+          light: "#4f8a4f",
+          dark: "#1d3f1d",
+          muted: "#e8f2e8",
+        },
+      },
+      fontFamily: {
+        heading: ["Playfair Display", ...defaultTheme.fontFamily.serif],
+        sans: ["Inter", ...defaultTheme.fontFamily.sans],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- extend the Tailwind theme with a reusable brand color palette and heading font family
- load the new fonts globally and add utility classes for brand-aligned headings
- refresh navigation, footer, home, and contact UI elements to use the text-brand and font-heading styles

## Testing
- npm test *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a517ab4c8327ab360c681ba80ae5