### PR TITLE
Redirect the root index to the Next.js storefront

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,24 +1,107 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>Al Noor Farm</title>
-    <link rel="icon" type="image/png" href="/assets/alnoorlogo.png" />
-    <style>
-      body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu;color:#0f172a}
-      .wrap{max-width:800px;margin:60px auto;padding:0 20px;text-align:center}
-      a{color:#2563eb}
-    </style>
-  </head>
-  <body>
-    <div class="wrap">
-      <img src="/assets/alnoorlogo.png" alt="Al Noor" style="height:96px;width:96px" />
-      <h1>Al Noor Farm</h1>
-      <p>Welcome. Use the links below to access the app.</p>
-      <p><a href="/alnoor/products">Store</a> • <a href="/alnoor/admin/login">Admin</a> • <a href="/alnoor/admin/pos">POS</a></p>
-      <p style="color:#475569;font-size:14px">If the app does not load, ensure the Node app in cPanel is running at <code>/alnoor</code>.</p>
-    </div>
-  </body>
-  </html>
-
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <title>Redirecting to Al Noor Farm</title>
+        <link rel="icon" type="image/png" href="/assets/alnoorlogo.png" />
+        <meta name="alnoor-target" content="/alnoor/" />
+        <meta http-equiv="refresh" content="0; url=/alnoor/" />
+        <style>
+            body {
+                margin: 0;
+                font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu;
+                color: #0f172a;
+                background-color: #f8fafc;
+            }
+            .wrap {
+                max-width: 640px;
+                margin: 96px auto;
+                padding: 0 24px;
+                text-align: center;
+            }
+            .logo {
+                height: 96px;
+                width: 96px;
+            }
+            .links {
+                display: flex;
+                gap: 8px;
+                align-items: center;
+                justify-content: center;
+                flex-wrap: wrap;
+                margin: 16px 0;
+            }
+            .links a {
+                color: #2563eb;
+                text-decoration: none;
+            }
+            .links a:hover {
+                text-decoration: underline;
+            }
+            .links span {
+                color: #94a3b8;
+            }
+            .note {
+                text-align: center;
+                color: #475569;
+                font-size: 14px;
+                margin-top: 24px;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="wrap" role="status" aria-live="polite">
+            <img src="/assets/alnoorlogo.png" alt="Al Noor" class="logo" />
+            <h1>Redirecting to Al Noor Farm</h1>
+            <p>You should be redirected to the updated storefront momentarily.</p>
+            <p>If the page does not change, continue with one of the quick links below.</p>
+            <p class="links" role="navigation" aria-label="Al Noor destinations">
+                <a data-alnoor-link="/products" href="/alnoor/products">Store</a>
+                <span aria-hidden="true">•</span>
+                <a data-alnoor-link="/admin/login" href="/alnoor/admin/login">Admin</a>
+                <span aria-hidden="true">•</span>
+                <a data-alnoor-link="/admin/pos" href="/alnoor/admin/pos">POS</a>
+            </p>
+        </div>
+        <noscript>
+            <p class="note">JavaScript is disabled; use the links above to reach the storefront.</p>
+        </noscript>
+        <script>
+            (function () {
+                var meta = document.querySelector('meta[name="alnoor-target"]');
+                var target = meta && meta.content ? meta.content : "/";
+                if (target.charAt(target.length - 1) !== "/") {
+                    target += "/";
+                }
+                var normalizedBase = target.replace(/\/$/, "");
+                if (!normalizedBase) {
+                    normalizedBase = "/";
+                }
+                var prefix = normalizedBase === "/" ? "" : normalizedBase;
+                var anchors = document.querySelectorAll("[data-alnoor-link]");
+                for (var i = 0; i < anchors.length; i += 1) {
+                    var anchor = anchors[i];
+                    var slug = anchor.getAttribute("data-alnoor-link") || "";
+                    if (slug && slug.charAt(0) !== "/") {
+                        slug = "/" + slug;
+                    }
+                    anchor.setAttribute("href", prefix + slug);
+                }
+                var currentPath = window.location.pathname;
+                if (!currentPath) {
+                    currentPath = "/";
+                }
+                if (currentPath.charAt(currentPath.length - 1) === "/" && currentPath.length > 1) {
+                    currentPath = currentPath.replace(/\/$/, "");
+                }
+                if (normalizedBase.charAt(normalizedBase.length - 1) === "/" && normalizedBase.length > 1) {
+                    normalizedBase = normalizedBase.replace(/\/$/, "");
+                }
+                if (currentPath !== normalizedBase) {
+                    window.location.replace(target);
+                }
+            })();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the root `index.html` with a meta refresh and script-based redirect into the Next.js app
- keep a styled fallback with quick links so Store, Admin, and POS remain reachable even if the redirect is blocked

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c8a51aa3f48327bbee61e262f9f6f6