### PR TITLE
feat: reorganize site navigation

### DIFF
--- a/frontend/__tests__/navbar.test.tsx
+++ b/frontend/__tests__/navbar.test.tsx
@@ -23,8 +23,17 @@ describe('Navbar', () => {
     );
     expect(screen.getByText('Al Noor')).toBeInTheDocument();
     expect(screen.getByRole('img', { name: /al noor/i })).toHaveAttribute('src', '/alnoorlogo.png');
-    expect(screen.getByRole('link', { name: 'Products' })).toHaveAttribute('href', '/products');
-    expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', '/contact');
+    const primaryLinks = [
+      { name: 'Home', href: '/' },
+      { name: 'Shop', href: '/products' },
+      { name: 'About', href: '/about' },
+      { name: 'Halal Process', href: '/halal-process' },
+      { name: 'FAQ', href: '/faq' },
+      { name: 'Contact', href: '/contact' },
+    ];
+    primaryLinks.forEach((link) => {
+      expect(screen.getByRole('link', { name: link.name })).toHaveAttribute('href', link.href);
+    });
     expect(screen.getByRole('link', { name: 'Checkout' })).toHaveAttribute('href', '/checkout');
     expect(screen.getByRole('link', { name: /Cart/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Admin' })).toHaveAttribute('href', '/admin/login');

--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,0 +1,43 @@
+export const metadata = {
+  title: "About | Al Noor Farm",
+  description: "Learn about Al Noor Farm's story, mission, and commitment to providing halal-certified meats.",
+};
+
+export default function AboutPage() {
+  return (
+    <section className="grid gap-6">
+      <h1 className="text-2xl font-semibold">About Al Noor Farm</h1>
+      <p className="text-slate-700">
+        Al Noor Farm is a family-run operation dedicated to providing the Western New York community with
+        ethically-raised animals and fully halal-certified meats. We believe in transparency, responsible
+        stewardship of the land, and honoring every customer who trusts us to nourish their families.
+      </p>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="border rounded p-4">
+          <h2 className="font-medium mb-2">Our Story</h2>
+          <p className="text-slate-700">
+            From humble beginnings as a small hobby farm, we have grown alongside the needs of our customers.
+            Today, our team oversees every step &mdash; from raising animals on open pastures to preparing
+            meat for pick-up &mdash; to ensure exceptional quality.
+          </p>
+        </div>
+        <div className="border rounded p-4">
+          <h2 className="font-medium mb-2">Our Mission</h2>
+          <p className="text-slate-700">
+            We are committed to sustainable practices, attentive care for every animal, and service rooted in
+            faith. Our goal is to make halal meat accessible, trustworthy, and convenient for families across
+            the region.
+          </p>
+        </div>
+      </div>
+      <div className="border rounded p-4">
+        <h2 className="font-medium mb-2">Community Focus</h2>
+        <p className="text-slate-700">
+          We proudly serve customers across Buffalo, Niagara Falls, Rochester, and beyond. Whether you are a
+          first-time visitor or a long-time partner, we welcome you to tour the farm, ask questions, and learn
+          more about our halal practices.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/faq/page.tsx
+++ b/frontend/app/faq/page.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "FAQ | Al Noor Farm",
+  description: "Frequently asked questions about ordering halal meat, visiting the farm, and working with Al Noor Farm.",
+};
+
+const faqs = [
+  {
+    question: "How do I place an order?",
+    answer:
+      "Browse the Shop to see current availability, add items to your cart, and complete checkout. We will confirm pickup windows once your order is received.",
+  },
+  {
+    question: "Do you offer delivery?",
+    answer:
+      "Local delivery is available for larger orders in the Buffalo and Niagara regions. Contact us to coordinate details and schedule a drop-off.",
+  },
+  {
+    question: "Can I visit the farm?",
+    answer:
+      "Yes, visits are welcome by appointment. We encourage guests to see our facilities and learn more about our halal practices.",
+  },
+  {
+    question: "What payment methods do you accept?",
+    answer:
+      "We accept cash, major credit cards, and invoiced payments for wholesale partners. Payment details are finalized during checkout or pickup.",
+  },
+];
+
+export default function FaqPage() {
+  return (
+    <section className="grid gap-6">
+      <h1 className="text-2xl font-semibold">Frequently Asked Questions</h1>
+      <div className="grid gap-4">
+        {faqs.map((item) => (
+          <div key={item.question} className="border rounded p-4">
+            <h2 className="font-medium mb-2">{item.question}</h2>
+            <p className="text-slate-700">{item.answer}</p>
+          </div>
+        ))}
+      </div>
+      <p className="text-slate-700">
+        Need something else? <Link className="text-blue-700 hover:underline" href="/contact">Reach out to our team</Link> and we
+        will be happy to help.
+      </p>
+    </section>
+  );
+}

--- a/frontend/app/halal-process/page.tsx
+++ b/frontend/app/halal-process/page.tsx
@@ -1,0 +1,47 @@
+export const metadata = {
+  title: "Halal Process | Al Noor Farm",
+  description: "Understand the halal process at Al Noor Farm, from animal care to Zabihah-compliant preparation.",
+};
+
+export default function HalalProcessPage() {
+  return (
+    <section className="grid gap-6">
+      <h1 className="text-2xl font-semibold">Our Halal Process</h1>
+      <p className="text-slate-700">
+        Every step of our process is designed to meet halal requirements and respect the animals under our
+        care. From sourcing and handling to the final preparation, we follow Zabihah standards so you can have
+        complete confidence in every order.
+      </p>
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="border rounded p-4">
+          <h2 className="font-medium mb-2">1. Humane Care</h2>
+          <p className="text-slate-700">
+            Animals are raised in clean, low-stress environments with access to open pasture and quality feed.
+            We monitor their health closely and avoid any unnecessary interventions.
+          </p>
+        </div>
+        <div className="border rounded p-4">
+          <h2 className="font-medium mb-2">2. Zabihah Preparation</h2>
+          <p className="text-slate-700">
+            A trained Muslim slaughterman recites the Tasmiya before each harvest and uses a swift, single
+            motion with a sharpened blade to minimize discomfort and ensure a proper halal cut.
+          </p>
+        </div>
+        <div className="border rounded p-4">
+          <h2 className="font-medium mb-2">3. Clean Handling</h2>
+          <p className="text-slate-700">
+            All equipment is sanitized between uses, and meat is cooled and packaged promptly so it reaches you
+            fresh and ready for pickup or delivery.
+          </p>
+        </div>
+      </div>
+      <div className="border rounded p-4">
+        <h2 className="font-medium mb-2">Visit the Farm</h2>
+        <p className="text-slate-700">
+          We welcome appointments to observe our process or ask additional questions. Contact us to schedule a
+          tour and experience the care we put into halal production firsthand.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -1,15 +1,29 @@
 "use client";
+
 import Link from "next/link";
 import Image from "next/image";
-import { useCart } from "@/context/CartContext";
-import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
 import ApiStatus from "@/components/ApiStatus";
+import { useCart } from "@/context/CartContext";
 import { fetchSession, logout as logoutSession } from "@/lib/api";
+
+const primaryLinks = [
+  { href: "/", label: "Home" },
+  { href: "/products", label: "Shop" },
+  { href: "/about", label: "About" },
+  { href: "/halal-process", label: "Halal Process" },
+  { href: "/faq", label: "FAQ" },
+  { href: "/contact", label: "Contact" },
+];
 
 export default function Navbar() {
   const { lines, total } = useCart();
-  const count = lines.reduce((acc, l) => acc + l.quantity, 0);
+  const count = lines.reduce((acc, line) => acc + line.quantity, 0);
   const [hasToken, setHasToken] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     let active = true;
@@ -25,13 +39,36 @@ export default function Navbar() {
     };
   }, []);
 
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
+
+  const adminLinks = useMemo(
+    () =>
+      hasToken
+        ? [
+            { href: "/admin/dashboard", label: "Dashboard" },
+            { href: "/admin/products", label: "Admin Products" },
+            { href: "/admin/orders", label: "Orders" },
+            { href: "/admin/pos", label: "POS" },
+            { href: "/admin/messages", label: "Messages" },
+            { href: "/admin/settings", label: "Settings" },
+          ]
+        : [{ href: "/admin/login", label: "Admin" }],
+    [hasToken],
+  );
+
+  const formattedCount = count.toFixed(0);
+  const formattedTotal = total.toFixed(2);
+
   async function logout() {
     try {
       await logoutSession();
-    } catch (err) {
-      console.error("Failed to log out", err);
+    } catch (error) {
+      console.error("Failed to log out", error);
     } finally {
       setHasToken(false);
+      setMenuOpen(false);
       if (typeof window !== "undefined") {
         window.location.href = "/";
       }
@@ -40,40 +77,106 @@ export default function Navbar() {
 
   return (
     <header className="border-b bg-white/80 backdrop-blur sticky top-0 z-10">
-      <nav className="max-w-5xl mx-auto px-6 py-3 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Link href="/" className="flex items-center gap-2 hover:opacity-80">
-            <Image src="/alnoorlogo.png" alt="Al Noor" width={24} height={24} />
-            <span className="font-semibold">Al Noor</span>
-          </Link>
-          <Link href="/products" className="text-slate-700 hover:underline">Products</Link>
-          <Link href="/contact" className="text-slate-700 hover:underline">Contact</Link>
-          <Link href="/checkout" className="text-slate-700 hover:underline">Checkout</Link>
-          {hasToken ? (
-            <>
-              <Link href="/admin/dashboard" className="text-slate-700 hover:underline">Dashboard</Link>
-              <Link href="/admin/products" className="text-slate-700 hover:underline">Admin Products</Link>
-              <Link href="/admin/orders" className="text-slate-700 hover:underline">Orders</Link>
-              <Link href="/admin/pos" className="text-slate-700 hover:underline">POS</Link>
-              <Link href="/admin/messages" className="text-slate-700 hover:underline">Messages</Link>
-              <Link href="/admin/settings" className="text-slate-700 hover:underline">Settings</Link>
-            </>
-          ) : (
-            <Link href="/admin/login" className="text-slate-700 hover:underline">Admin</Link>
-          )}
+      <nav className="max-w-5xl mx-auto px-6 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <Link href="/" className="flex items-center gap-2 hover:opacity-80">
+              <Image src="/alnoorlogo.png" alt="Al Noor" width={24} height={24} />
+              <span className="font-semibold">Al Noor</span>
+            </Link>
+            <div className="hidden md:flex items-center gap-4">
+              {primaryLinks.map((item) => (
+                <Link key={item.href} href={item.href} className="text-slate-700 hover:underline">
+                  {item.label}
+                </Link>
+              ))}
+              {adminLinks.map((item) => (
+                <Link key={item.href} href={item.href} className="text-slate-700 hover:underline">
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="hidden md:flex items-center gap-4">
+            <Link href="/cart" className="relative hover:underline">
+              Cart
+              <span className="ml-1 inline-flex items-center justify-center text-xs rounded-full bg-emerald-600 text-white px-2 py-0.5">
+                {formattedCount}
+              </span>
+            </Link>
+            <div className="text-sm text-slate-600">${formattedTotal}</div>
+            <Link href="/checkout" className="text-slate-700 hover:underline">
+              Checkout
+            </Link>
+            {hasToken && (
+              <button onClick={logout} className="text-slate-600 hover:underline text-sm">
+                Logout
+              </button>
+            )}
+          </div>
+          <button
+            type="button"
+            className="md:hidden inline-flex h-10 w-10 items-center justify-center rounded border border-slate-200 text-slate-700 hover:bg-slate-100"
+            onClick={() => setMenuOpen((open) => !open)}
+            aria-expanded={menuOpen}
+            aria-label="Toggle navigation"
+          >
+            <span className="sr-only">Toggle navigation</span>
+            <svg
+              aria-hidden="true"
+              className="h-5 w-5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              {menuOpen ? (
+                <path d="M6 18L18 6M6 6l12 12" />
+              ) : (
+                <path d="M4 6h16M4 12h16M4 18h16" />
+              )}
+            </svg>
+          </button>
         </div>
-        <div className="flex items-center gap-4">
-          <Link href="/cart" className="relative hover:underline">
-            Cart
-            <span className="ml-1 inline-flex items-center justify-center text-xs rounded-full bg-emerald-600 text-white px-2 py-0.5">
-              {count.toFixed(0)}
-            </span>
-          </Link>
-          <div className="text-sm text-slate-600 hidden sm:block">${total.toFixed(2)}</div>
-          {hasToken && (
-            <button onClick={logout} className="text-slate-600 hover:underline text-sm">Logout</button>
-          )}
-        </div>
+        {menuOpen && (
+          <div className="md:hidden mt-4 border-t border-slate-200 pt-4 grid gap-4">
+            <div className="grid gap-2">
+              {primaryLinks.map((item) => (
+                <Link key={item.href} href={item.href} className="text-slate-700 hover:underline">
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+            <div className="grid gap-2">
+              {adminLinks.map((item) => (
+                <Link key={item.href} href={item.href} className="text-slate-700 hover:underline">
+                  {item.label}
+                </Link>
+              ))}
+              {hasToken && (
+                <button onClick={logout} className="text-left text-sm text-slate-600 hover:underline">
+                  Logout
+                </button>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Link href="/cart" className="flex items-center justify-between text-slate-700 hover:underline">
+                <span>
+                  Cart
+                  <span className="ml-2 inline-flex items-center justify-center rounded-full bg-emerald-600 px-2 py-0.5 text-xs font-medium text-white">
+                    {formattedCount}
+                  </span>
+                </span>
+                <span className="text-sm text-slate-500">${formattedTotal}</span>
+              </Link>
+              <Link href="/checkout" className="text-slate-700 hover:underline">
+                Checkout
+              </Link>
+            </div>
+          </div>
+        )}
       </nav>
       <ApiStatus />
     </header>


### PR DESCRIPTION
## Summary
- reorganize the navbar links for desktop and mobile so Home, Shop, About, Halal Process, FAQ, Contact, and admin/cart actions are consistent
- add new About, Halal Process, and FAQ pages to back the new navigation items
- update the navbar test to reflect the revised menu labels

## Testing
- NODE_ENV=test npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68c8a594c6348327af3a329aa572fec0