### PR TITLE
fix: improve mobile layouts for storefront and admin

### DIFF
--- a/frontend/__tests__/navbar.test.tsx
+++ b/frontend/__tests__/navbar.test.tsx
@@ -23,10 +23,17 @@ describe('Navbar', () => {
     );
     expect(screen.getByText('Al Noor')).toBeInTheDocument();
     expect(screen.getByRole('img', { name: /al noor/i })).toHaveAttribute('src', '/alnoorlogo.png');
-    expect(screen.getByRole('link', { name: 'Products' })).toHaveAttribute('href', '/products');
-    expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', '/contact');
-    expect(screen.getByRole('link', { name: 'Checkout' })).toHaveAttribute('href', '/checkout');
-    expect(screen.getByRole('link', { name: /Cart/ })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Admin' })).toHaveAttribute('href', '/admin/login');
+    const expectLink = (name: string | RegExp, href?: string) => {
+      const links = screen.getAllByRole('link', { name });
+      expect(links.length).toBeGreaterThan(0);
+      if (href) {
+        expect(links.some((link) => link.getAttribute('href') === href)).toBe(true);
+      }
+    };
+    expectLink('Products', '/products');
+    expectLink('Contact', '/contact');
+    expectLink('Checkout', '/checkout');
+    expectLink(/Cart/);
+    expectLink('Admin', '/admin/login');
   });
 });

--- a/frontend/app/admin/dashboard/page.tsx
+++ b/frontend/app/admin/dashboard/page.tsx
@@ -58,7 +58,7 @@ export default async function AdminDashboardPage() {
         <>
           <div className="border rounded p-3">
             <div className="text-xs text-slate-600">System Status</div>
-            <div className="text-sm text-slate-700 flex items-center gap-4">
+            <div className="flex flex-wrap items-center gap-3 text-sm text-slate-700">
               <span>API: <strong className={apiHealth==='ok' ? 'text-emerald-700' : 'text-red-700'}>{apiHealth||'unknown'}</strong></span>
               <span>App: <strong className={appHealth==='ok' ? 'text-emerald-700' : 'text-red-700'}>{appHealth||'unknown'}</strong></span>
             </div>
@@ -100,7 +100,10 @@ export default async function AdminDashboardPage() {
             ) : (
               <ul className="grid gap-2">
                 {metrics.low_stock.map((p) => (
-                  <li key={p.id} className="border rounded p-2 flex items-center justify-between">
+                  <li
+                    key={p.id}
+                    className="border rounded p-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+                  >
                     <div>{p.name}</div>
                     <div className="text-sm text-slate-700">{p.stock} {p.unit || ""}</div>
                   </li>

--- a/frontend/app/admin/messages/page.tsx
+++ b/frontend/app/admin/messages/page.tsx
@@ -56,7 +56,7 @@ export default function AdminMessagesPage() {
     <section>
       <h1 className="text-2xl font-semibold mb-4">Contact Messages</h1>
       {error && (
-        <div className="mb-3 text-red-700 bg-red-50 border border-red-200 p-2 rounded flex items-center justify-between" role="alert">
+        <div className="mb-3 flex flex-col gap-2 rounded border border-red-200 bg-red-50 p-2 text-red-700 sm:flex-row sm:items-center sm:justify-between" role="alert">
           <span>{error}</span>
           <button onClick={load} className="text-red-800 underline text-sm">Retry</button>
         </div>
@@ -69,7 +69,7 @@ export default function AdminMessagesPage() {
         <ul className="grid gap-2">
           {messages.map((m) => (
             <li key={m.id} className="border rounded p-3">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                 <div className="font-medium">{m.name || "(No name)"}</div>
                 <div className="text-xs text-slate-500">{new Date(m.created_at).toLocaleString()}</div>
               </div>

--- a/frontend/app/admin/orders/page.tsx
+++ b/frontend/app/admin/orders/page.tsx
@@ -91,23 +91,23 @@ export default function AdminOrdersPage() {
   return (
     <section>
       <h1 className="text-2xl font-semibold mb-4">Orders</h1>
-      <div className="flex items-center gap-3 mb-2 flex-wrap">
+      <div className="mb-2 grid gap-2 sm:flex sm:flex-wrap sm:items-center sm:gap-3">
         <label className="text-sm text-slate-600" htmlFor="statusFilter">Status</label>
-        <select id="statusFilter" className="border rounded px-2 py-1 text-sm" value={statusFilter} onChange={(e)=> setStatusFilter(e.target.value)}>
+        <select id="statusFilter" className="w-full rounded border px-2 py-1 text-sm sm:w-auto" value={statusFilter} onChange={(e)=> setStatusFilter(e.target.value)}>
           {['all','pending','paid','processing','completed','cancelled'].map(s=> (
             <option key={s} value={s}>{s}</option>
           ))}
         </select>
         <input id="orderIdFilter"
-          className="border rounded px-2 py-1 text-sm"
+          className="w-full rounded border px-2 py-1 text-sm sm:w-auto"
           placeholder="Order ID"
           value={idQuery}
           onChange={(e)=> setIdQuery(e.target.value)}
         />
         <label className="text-sm text-slate-600" htmlFor="fromDate">From</label>
-        <input id="fromDate" type="date" className="border rounded px-2 py-1 text-sm" value={fromDate} onChange={(e)=> setFromDate(e.target.value)} />
+        <input id="fromDate" type="date" className="w-full rounded border px-2 py-1 text-sm sm:w-auto" value={fromDate} onChange={(e)=> setFromDate(e.target.value)} />
         <label className="text-sm text-slate-600" htmlFor="toDate">To</label>
-        <input id="toDate" type="date" className="border rounded px-2 py-1 text-sm" value={toDate} onChange={(e)=> setToDate(e.target.value)} />
+        <input id="toDate" type="date" className="w-full rounded border px-2 py-1 text-sm sm:w-auto" value={toDate} onChange={(e)=> setToDate(e.target.value)} />
         <button onClick={load} className="text-blue-700 hover:underline text-sm">Apply</button>
         <button onClick={()=>{ setFromDate(""); setToDate(""); load(); }} className="text-slate-600 hover:underline text-sm">Clear</button>
         <span className="text-xs text-slate-500">Quick:</span>
@@ -193,7 +193,7 @@ export default function AdminOrdersPage() {
         >Export CSV</button>
       </div>
       {error && (
-        <div className="mb-3 text-red-700 bg-red-50 border border-red-200 p-2 rounded flex items-center justify-between" role="alert">
+        <div className="mb-3 flex flex-col gap-2 rounded border border-red-200 bg-red-50 p-2 text-red-700 sm:flex-row sm:items-center sm:justify-between" role="alert">
           <span>{error}</span>
           <button onClick={load} className="text-red-800 underline text-sm">Retry</button>
         </div>
@@ -206,7 +206,7 @@ export default function AdminOrdersPage() {
         <ul className="grid gap-3">
           {filtered.map((o) => (
             <li key={o.id} className="border rounded p-3">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div className="font-medium flex items-center gap-2">
                   <a className="hover:underline" href={`/admin/orders/${o.id}`}>Order #{o.id}</a>
                   <button

--- a/frontend/app/admin/pos/page.tsx
+++ b/frontend/app/admin/pos/page.tsx
@@ -156,10 +156,10 @@ export default function PosPage() {
         </div>
       )}
       <div className="flex gap-2 items-end mb-4 flex-wrap">
-        <div>
+        <div className="w-full sm:w-auto">
           <label className="block text-sm text-slate-600">Product</label>
           <select
-            className="border rounded px-2 py-1 min-w-[200px]"
+            className="w-full rounded border px-2 py-1 sm:min-w-[200px]"
             value={selectedId}
             onChange={(e) => setSelectedId(e.target.value)}
           >
@@ -171,7 +171,7 @@ export default function PosPage() {
             ))}
           </select>
         </div>
-        <div>
+        <div className="w-full sm:w-auto">
           {(() => {
             const sel = products.find((p) => String(p.id) === selectedId) as any;
             const isWeight = sel?.is_weight_based;
@@ -182,7 +182,7 @@ export default function PosPage() {
                   {isWeight ? `Weight (${unit})` : "Quantity"}
                 </label>
                 <input
-                  className="border rounded px-2 py-1 w-28"
+                  className="w-full rounded border px-2 py-1 sm:w-28"
                   value={qty}
                   onChange={(e) => setQty(e.target.value)}
                   type="number"
@@ -195,7 +195,7 @@ export default function PosPage() {
         </div>
         <button
           onClick={addItem}
-          className="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700"
+          className="w-full rounded bg-blue-600 px-3 py-1 text-white hover:bg-blue-700 sm:w-auto"
         >
           Add to Sale
         </button>
@@ -203,25 +203,28 @@ export default function PosPage() {
 
       <ul className="grid gap-2 mb-4">
         {sale.map((s) => (
-          <li key={s.product.id} className="border rounded p-2 flex items-center justify-between">
-            <div>
+          <li
+            key={s.product.id}
+            className="border rounded p-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="w-full sm:flex-1">
               <div className="font-medium">{s.product.name}</div>
               <div className="text-sm text-slate-600">
                 {s.quantity} {(s.product as any).unit || "unit"} x ${s.product.price.toFixed(2)}
               </div>
             </div>
-            <div className="font-semibold">
+            <div className="font-semibold sm:text-right">
               ${(s.product.price * s.quantity).toFixed(2)}
             </div>
           </li>
         ))}
       </ul>
 
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="text-lg font-semibold">Total: ${total.toFixed(2)}</div>
-        <div className="flex items-center gap-2">
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
           <input
-            className="border rounded px-2 py-1"
+            className="w-full rounded border px-2 py-1 sm:w-auto"
             placeholder="Terminal Device ID (optional)"
             value={deviceId}
             onChange={(e) => setDeviceId(e.target.value)}
@@ -229,14 +232,14 @@ export default function PosPage() {
           <button
             onClick={checkout}
             disabled={loading || sale.length === 0}
-            className="bg-emerald-600 text-white px-3 py-1 rounded hover:bg-emerald-700 disabled:opacity-60"
+            className="w-full rounded bg-emerald-600 px-3 py-1 text-white hover:bg-emerald-700 disabled:opacity-60 sm:w-auto"
           >
             {loading ? "Processing..." : "Checkout (simulate)"}
           </button>
           <button
             onClick={checkoutWithTerminal}
             disabled={loading || sale.length === 0}
-            className="bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 disabled:opacity-60"
+            className="w-full rounded bg-blue-600 px-3 py-1 text-white hover:bg-blue-700 disabled:opacity-60 sm:w-auto"
           >
             {loading ? "Processing..." : "Use Square Terminal"}
           </button>
@@ -249,7 +252,7 @@ export default function PosPage() {
               }catch(e:any){ setError(e.message||'Cash checkout failed'); } finally { setLoading(false); }
             }}
             disabled={loading || sale.length === 0}
-            className="bg-slate-700 text-white px-3 py-1 rounded hover:bg-slate-800 disabled:opacity-60"
+            className="w-full rounded bg-slate-700 px-3 py-1 text-white hover:bg-slate-800 disabled:opacity-60 sm:w-auto"
           >
             {loading ? 'Processing...' : 'Cash'}
           </button>

--- a/frontend/app/admin/products/page.tsx
+++ b/frontend/app/admin/products/page.tsx
@@ -236,62 +236,111 @@ export default function AdminProductsPage() {
         </div>
       )}
       {error && (
-        <div className="mb-3 text-red-700 bg-red-50 border border-red-200 p-2 rounded flex items-center justify-between" role="alert">
+        <div className="mb-3 flex flex-col gap-2 rounded border border-red-200 bg-red-50 p-2 text-red-700 sm:flex-row sm:items-center sm:justify-between" role="alert">
           <span>{error}</span>
           <button onClick={load} className="text-red-800 underline text-sm">Retry</button>
         </div>
       )}
 
-      <form onSubmit={onCreate} className="mb-6 flex gap-2 items-end flex-wrap">
-        <div>
+      <form onSubmit={onCreate} className="mb-6 grid gap-3 sm:flex sm:flex-wrap sm:items-end">
+        <div className="w-full sm:min-w-[200px]">
           <label className="block text-sm text-slate-600" htmlFor="prodName">Name</label>
-          <input id="prodName" className="border rounded px-2 py-1" value={name} onChange={(e)=> setName(e.target.value)} placeholder="Product name" aria-invalid={!!fieldErrors.name} aria-describedby={fieldErrors.name ? 'errName' : undefined} />
-          {fieldErrors.name && <div className="text-xs text-red-700 mt-1">{fieldErrors.name}</div>}
+          <input
+            id="prodName"
+            className="w-full rounded border px-2 py-1"
+            value={name}
+            onChange={(e)=> setName(e.target.value)}
+            placeholder="Product name"
+            aria-invalid={!!fieldErrors.name}
+            aria-describedby={fieldErrors.name ? 'errName' : undefined}
+          />
+          {fieldErrors.name && (
+            <div id="errName" className="mt-1 text-xs text-red-700">{fieldErrors.name}</div>
+          )}
         </div>
-        <div>
+        <div className="w-full sm:min-w-[140px] sm:w-auto">
           <label className="block text-sm text-slate-600" htmlFor="prodPrice">Price (USD)</label>
-          <input id="prodPrice" type="number" step="0.01" min="0" className="border rounded px-2 py-1" value={price} onChange={(e)=> setPrice(e.target.value)} aria-invalid={!!fieldErrors.price} aria-describedby={fieldErrors.price ? 'errPrice' : undefined} />
-          {fieldErrors.price && <div className="text-xs text-red-700 mt-1">{fieldErrors.price}</div>}
+          <input
+            id="prodPrice"
+            type="number"
+            step="0.01"
+            min="0"
+            className="w-full rounded border px-2 py-1 sm:w-32"
+            value={price}
+            onChange={(e)=> setPrice(e.target.value)}
+            aria-invalid={!!fieldErrors.price}
+            aria-describedby={fieldErrors.price ? 'errPrice' : undefined}
+          />
+          {fieldErrors.price && (
+            <div id="errPrice" className="mt-1 text-xs text-red-700">{fieldErrors.price}</div>
+          )}
         </div>
-        <div>
+        <div className="w-full sm:min-w-[140px] sm:w-auto">
           <label className="block text-sm text-slate-600" htmlFor="prodStock">Stock</label>
-          <input id="prodStock" type="number" step="0.01" min="0" className="border rounded px-2 py-1" value={stock} onChange={(e)=> setStock(e.target.value)} aria-invalid={!!fieldErrors.stock} aria-describedby={fieldErrors.stock ? 'errStock' : undefined} />
-          {fieldErrors.stock && <div className="text-xs text-red-700 mt-1">{fieldErrors.stock}</div>}
+          <input
+            id="prodStock"
+            type="number"
+            step="0.01"
+            min="0"
+            className="w-full rounded border px-2 py-1 sm:w-32"
+            value={stock}
+            onChange={(e)=> setStock(e.target.value)}
+            aria-invalid={!!fieldErrors.stock}
+            aria-describedby={fieldErrors.stock ? 'errStock' : undefined}
+          />
+          {fieldErrors.stock && (
+            <div id="errStock" className="mt-1 text-xs text-red-700">{fieldErrors.stock}</div>
+          )}
         </div>
-        <div>
+        <div className="w-full sm:min-w-[160px] sm:w-auto">
           <label className="block text-sm text-slate-600" htmlFor="prodUnit">Unit</label>
-          <input id="prodUnit" className="border rounded px-2 py-1" value={unit} onChange={(e)=> setUnit(e.target.value)} placeholder="each, lb, dozen, ..." aria-invalid={!!fieldErrors.unit} aria-describedby={fieldErrors.unit ? 'errUnit' : undefined} />
-          {fieldErrors.unit && <div className="text-xs text-red-700 mt-1">{fieldErrors.unit}</div>}
+          <input
+            id="prodUnit"
+            className="w-full rounded border px-2 py-1"
+            value={unit}
+            onChange={(e)=> setUnit(e.target.value)}
+            placeholder="each, lb, dozen, ..."
+            aria-invalid={!!fieldErrors.unit}
+            aria-describedby={fieldErrors.unit ? 'errUnit' : undefined}
+          />
+          {fieldErrors.unit && (
+            <div id="errUnit" className="mt-1 text-xs text-red-700">{fieldErrors.unit}</div>
+          )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex w-full items-center gap-2 sm:w-auto">
           <input id="isWeightBased" type="checkbox" checked={isWeightBased} onChange={(e)=> setIsWeightBased(e.target.checked)} />
           <label htmlFor="isWeightBased" className="text-sm text-slate-600">Weight-based</label>
         </div>
-        <div>
+        <div className="w-full sm:min-w-[260px]">
           <label className="block text-sm text-slate-600">Image URL</label>
-          <input className="border rounded px-2 py-1 min-w-[280px]" value={imageUrl} onChange={(e)=> setImageUrl(e.target.value)} placeholder="https://..." />
+          <input
+            className="w-full rounded border px-2 py-1"
+            value={imageUrl}
+            onChange={(e)=> setImageUrl(e.target.value)}
+            placeholder="https://..."
+          />
         </div>
-        <div className="w-full max-w-xl">
+        <div className="w-full sm:max-w-xl">
           <label className="block text-sm text-slate-600">Description</label>
           <textarea className="border rounded px-2 py-1 w-full" rows={3} value={desc} onChange={(e)=> setDesc(e.target.value)} placeholder="Short description..." />
         </div>
-        <button type="submit" className="bg-emerald-600 text-white px-3 py-1 rounded hover:bg-emerald-700">Add</button>
+        <button type="submit" className="w-full rounded bg-emerald-600 px-3 py-1 text-white hover:bg-emerald-700 sm:w-auto">Add</button>
       </form>
 
-      <div className="mb-4 flex items-center gap-3 flex-wrap">
+      <div className="mb-4 grid gap-2 sm:flex sm:flex-wrap sm:items-center">
         <input
-          className="border rounded px-2 py-1"
+          className="w-full rounded border px-2 py-1 sm:flex-1 sm:w-auto"
           placeholder="Filter by name, unit, or description..."
           value={query}
           onChange={(e)=> setQuery(e.target.value)}
         />
         <label className="text-sm text-slate-600">Sort</label>
-        <select className="border rounded px-2 py-1 text-sm" value={sortBy} onChange={(e)=> setSortBy(e.target.value as any)}>
+        <select className="w-full rounded border px-2 py-1 text-sm sm:w-auto" value={sortBy} onChange={(e)=> setSortBy(e.target.value as any)}>
           <option value="name">Name</option>
           <option value="price">Price</option>
           <option value="stock">Stock</option>
         </select>
-        <select className="border rounded px-2 py-1 text-sm" value={sortDir} onChange={(e)=> setSortDir(e.target.value as any)}>
+        <select className="w-full rounded border px-2 py-1 text-sm sm:w-auto" value={sortDir} onChange={(e)=> setSortDir(e.target.value as any)}>
           <option value="asc">Asc</option>
           <option value="desc">Desc</option>
         </select>
@@ -300,7 +349,7 @@ export default function AdminProductsPage() {
           type="number"
           step="0.1"
           min="0"
-          className="border rounded px-2 py-1 w-24 text-sm"
+          className="w-full rounded border px-2 py-1 text-sm sm:w-24"
           value={lowThreshold}
           onChange={(e)=> setLowThreshold(parseFloat(e.target.value)||0)}
         />
@@ -332,6 +381,7 @@ export default function AdminProductsPage() {
           type="file"
           accept=".csv,text/csv"
           aria-label="Import products from CSV"
+          className="w-full sm:w-auto"
           onChange={async (e)=>{
             const file = e.target.files?.[0]; if(!file) return;
             try{
@@ -368,34 +418,37 @@ export default function AdminProductsPage() {
       ) : (
         <ul className="grid gap-2">
           {sorted.map((p) => (
-            <li key={p.id} className={`border rounded p-3 flex items-center justify-between gap-4 ${((p as any).stock||0) <= lowThreshold ? 'border-red-300 bg-red-50' : ''}`}>
+            <li
+              key={p.id}
+              className={`border rounded p-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between ${((p as any).stock||0) <= lowThreshold ? 'border-red-300 bg-red-50' : ''}`}
+            >
               {editingId === p.id ? (
-                <div className="flex-1 flex items-end gap-2 flex-wrap">
-                  <div>
+                <div className="flex-1 grid gap-2 sm:flex sm:flex-wrap sm:items-end">
+                  <div className="w-full sm:w-auto">
                     <label className="block text-xs text-slate-600">Name</label>
-                    <input className="border rounded px-2 py-1" value={editName} onChange={(e)=> setEditName(e.target.value)} />
+                    <input className="w-full rounded border px-2 py-1" value={editName} onChange={(e)=> setEditName(e.target.value)} />
                   </div>
-                  <div>
+                  <div className="w-full sm:w-auto">
                     <label className="block text-xs text-slate-600">Price</label>
-                    <input type="number" step="0.01" min="0" className="border rounded px-2 py-1" value={editPrice} onChange={(e)=> setEditPrice(e.target.value)} />
+                    <input type="number" step="0.01" min="0" className="w-full rounded border px-2 py-1 sm:w-32" value={editPrice} onChange={(e)=> setEditPrice(e.target.value)} />
                   </div>
-                  <div>
+                  <div className="w-full sm:w-auto">
                     <label className="block text-xs text-slate-600">Stock</label>
-                    <input type="number" step="0.01" min="0" className="border rounded px-2 py-1" value={editStock} onChange={(e)=> setEditStock(e.target.value)} />
+                    <input type="number" step="0.01" min="0" className="w-full rounded border px-2 py-1 sm:w-32" value={editStock} onChange={(e)=> setEditStock(e.target.value)} />
                   </div>
-                  <div>
+                  <div className="w-full sm:w-auto">
                     <label className="block text-xs text-slate-600">Unit</label>
-                    <input className="border rounded px-2 py-1" value={editUnit} onChange={(e)=> setEditUnit(e.target.value)} />
+                    <input className="w-full rounded border px-2 py-1" value={editUnit} onChange={(e)=> setEditUnit(e.target.value)} />
                   </div>
-                  <div className="flex items-center gap-2 pt-5">
+                  <div className="flex items-center gap-2 pt-2 sm:pt-5">
                     <input id="editIsWeightBased" type="checkbox" checked={editIsWeightBased} onChange={(e)=> setEditIsWeightBased(e.target.checked)} />
                     <label htmlFor="editIsWeightBased" className="text-xs text-slate-600">Weight-based</label>
                   </div>
-                  <div>
+                  <div className="w-full sm:w-auto">
                     <label className="block text-xs text-slate-600">Image URL</label>
-                    <input className="border rounded px-2 py-1 min-w-[260px]" value={editImageUrl} onChange={(e)=> setEditImageUrl(e.target.value)} />
+                    <input className="w-full rounded border px-2 py-1 sm:min-w-[260px]" value={editImageUrl} onChange={(e)=> setEditImageUrl(e.target.value)} />
                   </div>
-                  <div className="w-full max-w-xl">
+                  <div className="w-full sm:max-w-xl">
                     <label className="block text-xs text-slate-600">Description</label>
                     <textarea className="border rounded px-2 py-1 w-full" rows={2} value={editDesc} onChange={(e)=> setEditDesc(e.target.value)} />
                   </div>
@@ -408,8 +461,10 @@ export default function AdminProductsPage() {
                   </div>
                 </div>
               )}
-              <div className="flex items-center gap-3">
-                {(p as any).image_url ? (<img src={(p as any).image_url} alt={p.name} className="h-10 w-10 object-cover rounded border" />) : null}
+              <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap sm:gap-3">
+                {(p as any).image_url ? (
+                  <img src={(p as any).image_url} alt={p.name} className="h-12 w-12 rounded border object-cover" />
+                ) : null}
                 {editingId === p.id ? (
                   <>
                     <button onClick={onSaveEdit} className="text-emerald-700 hover:underline">Save</button>

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -56,7 +56,7 @@ export default function AdminSettingsPage() {
       <div className="border rounded p-4">
         <h2 className="font-medium mb-2">Low Stock Threshold</h2>
         <div className="text-sm text-slate-600 mb-2">Used to highlight products with low inventory.</div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <input
             className="border rounded px-2 py-1 w-24"
             type="number"

--- a/frontend/app/cart/page.tsx
+++ b/frontend/app/cart/page.tsx
@@ -13,32 +13,41 @@ export default function CartPage() {
         <>
           <ul className="grid gap-2 mb-4">
             {lines.map((l) => (
-              <li key={l.product.id} className="border rounded p-3 flex items-center justify-between gap-4">
-                <div>
+              <li
+                key={l.product.id}
+                className="border rounded p-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="w-full sm:flex-1">
                   <div className="font-medium">{l.product.name}</div>
                   <div className="text-sm text-slate-600">
                     ${l.product.price.toFixed(2)} / {(l.product as any).unit || "unit"}
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
                   <input
-                    className="border rounded px-2 py-1 w-24"
+                    className="border rounded px-2 py-1 w-full sm:w-24"
                     type="number"
                     min={(l.product as any).is_weight_based ? 0 : 1}
                     step={(l.product as any).is_weight_based ? 0.1 : 1}
                     value={l.quantity}
                     onChange={(e) => update(l.product.id, parseFloat(e.target.value))}
                   />
-                  <button onClick={() => remove(l.product.id)} className="text-red-700 hover:underline">
+                  <button
+                    onClick={() => remove(l.product.id)}
+                    className="self-start text-left text-red-700 hover:underline sm:self-auto sm:text-right"
+                  >
                     Remove
                   </button>
                 </div>
               </li>
             ))}
           </ul>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="text-lg font-semibold">Total: ${total.toFixed(2)}</div>
-            <Link href="/checkout" className="bg-emerald-600 text-white px-3 py-1 rounded hover:bg-emerald-700">
+            <Link
+              href="/checkout"
+              className="w-full rounded bg-emerald-600 px-3 py-1 text-center text-white hover:bg-emerald-700 sm:w-auto"
+            >
               Checkout
             </Link>
           </div>

--- a/frontend/app/checkout/page.tsx
+++ b/frontend/app/checkout/page.tsx
@@ -93,7 +93,7 @@ export default function CheckoutPage() {
         ) : null}
         <button
           type="submit"
-          className="bg-slate-700 text-white px-3 py-1 rounded hover:bg-slate-800"
+          className="w-full rounded bg-slate-700 px-3 py-1 text-white hover:bg-slate-800 sm:w-auto"
           disabled={loading}
         >
           {loading ? "Placing order..." : "Place Order (simulate)"}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -47,7 +47,7 @@ export default function RootLayout({
       <body className="min-h-screen antialiased text-slate-800">
         <Providers>
           <Navbar />
-          <main className="max-w-5xl mx-auto p-6">{children}</main>
+          <main className="max-w-5xl mx-auto px-4 py-6 sm:px-6">{children}</main>
           <Footer />
         </Providers>
       </body>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -16,10 +16,16 @@ export default function Home() {
       <p className="text-slate-600 mb-6">
         Browse products, manage inventory, and run POS.
       </p>
-      <div className="flex gap-4 justify-center">
-        <Link className="text-blue-600 hover:underline" href="/products">Store</Link>
-        <Link className="text-blue-600 hover:underline" href="/admin/login">Admin</Link>
-        <Link className="text-blue-600 hover:underline" href="/admin/pos">POS</Link>
+      <div className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
+        <Link className="text-blue-600 hover:underline" href="/products">
+          Store
+        </Link>
+        <Link className="text-blue-600 hover:underline" href="/admin/login">
+          Admin
+        </Link>
+        <Link className="text-blue-600 hover:underline" href="/admin/pos">
+          POS
+        </Link>
       </div>
     </div>
   );

--- a/frontend/app/products/[id]/page.tsx
+++ b/frontend/app/products/[id]/page.tsx
@@ -13,8 +13,12 @@ export default async function ProductDetailPage({ params }: Props) {
   return (
     <section>
       <h1 className="text-2xl font-semibold mb-2">{product.name}</h1>
-      { (product as any).image_url ? (
-        <img src={(product as any).image_url} alt={product.name} className="mb-3 max-h-64 rounded border" />
+      {(product as any).image_url ? (
+        <img
+          src={(product as any).image_url}
+          alt={product.name}
+          className="mb-3 h-auto w-full max-h-64 rounded border object-cover"
+        />
       ) : null}
       <p className="text-slate-700 mb-4">
         ${product.price.toFixed(2)} / {(product as any).unit || "unit"}

--- a/frontend/app/products/[id]/widgets/AddToCart.tsx
+++ b/frontend/app/products/[id]/widgets/AddToCart.tsx
@@ -33,7 +33,7 @@ export default function AddToCart({ product }: { product: Product }) {
       </div>
       <button
         onClick={onAdd}
-        className="bg-emerald-600 text-white px-3 py-1 rounded hover:bg-emerald-700"
+        className="w-full rounded bg-emerald-600 px-3 py-1 text-white hover:bg-emerald-700 sm:w-auto"
       >
         Add to Cart
       </button>

--- a/frontend/app/products/page.tsx
+++ b/frontend/app/products/page.tsx
@@ -36,15 +36,17 @@ export default async function ProductsPage({ searchParams }: Props) {
           }),
         }}
       />
-      <form method="get" className="mb-4 flex items-center gap-2">
+      <form method="get" className="mb-4 flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
         <input
-          className="border rounded px-2 py-1"
+          className="border rounded px-2 py-1 w-full sm:w-auto sm:flex-1"
           type="search"
           name="q"
           placeholder="Search products..."
           defaultValue={q}
         />
-        <button className="px-3 py-1 rounded bg-slate-700 text-white">Search</button>
+        <button className="w-full rounded bg-slate-700 px-3 py-1 text-white sm:w-auto" type="submit">
+          Search
+        </button>
       </form>
       {filtered.length === 0 ? (
         <p className="text-slate-600">No products available yet.</p>

--- a/frontend/components/ApiStatus.tsx
+++ b/frontend/components/ApiStatus.tsx
@@ -28,7 +28,7 @@ export default function ApiStatus() {
   if (!down) return null;
   return (
     <div className="bg-red-50 border-t border-red-200 text-red-700 text-sm">
-      <div className="max-w-5xl mx-auto px-6 py-2">API seems unreachable: {msg}</div>
+      <div className="max-w-5xl mx-auto px-4 py-2 sm:px-6">API seems unreachable: {msg}</div>
     </div>
   );
 }

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,7 +1,7 @@
 export default function Footer() {
   return (
     <footer className="border-t mt-8">
-      <div className="max-w-5xl mx-auto px-6 py-6 text-sm text-slate-600 grid gap-2 sm:flex sm:items-center sm:justify-between">
+      <div className="max-w-5xl mx-auto px-4 py-6 text-sm text-slate-600 grid gap-2 sm:flex sm:items-center sm:justify-between sm:px-6">
         <div>© {new Date().getFullYear()} Al Noor Farm</div>
         <div className="flex items-center gap-3 flex-wrap">
           <a className="hover:underline" href="/products">Store</a>

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -5,11 +5,14 @@ import { useCart } from "@/context/CartContext";
 import { useEffect, useState } from "react";
 import ApiStatus from "@/components/ApiStatus";
 import { fetchSession, logout as logoutSession } from "@/lib/api";
+import { usePathname } from "next/navigation";
 
 export default function Navbar() {
   const { lines, total } = useCart();
   const count = lines.reduce((acc, l) => acc + l.quantity, 0);
   const [hasToken, setHasToken] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     let active = true;
@@ -32,47 +35,161 @@ export default function Navbar() {
       console.error("Failed to log out", err);
     } finally {
       setHasToken(false);
+      setMenuOpen(false);
       if (typeof window !== "undefined") {
         window.location.href = "/";
       }
     }
   }
 
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
+
   return (
     <header className="border-b bg-white/80 backdrop-blur sticky top-0 z-10">
-      <nav className="max-w-5xl mx-auto px-6 py-3 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Link href="/" className="flex items-center gap-2 hover:opacity-80">
-            <Image src="/alnoorlogo.png" alt="Al Noor" width={24} height={24} />
-            <span className="font-semibold">Al Noor</span>
-          </Link>
-          <Link href="/products" className="text-slate-700 hover:underline">Products</Link>
-          <Link href="/contact" className="text-slate-700 hover:underline">Contact</Link>
-          <Link href="/checkout" className="text-slate-700 hover:underline">Checkout</Link>
-          {hasToken ? (
-            <>
-              <Link href="/admin/dashboard" className="text-slate-700 hover:underline">Dashboard</Link>
-              <Link href="/admin/products" className="text-slate-700 hover:underline">Admin Products</Link>
-              <Link href="/admin/orders" className="text-slate-700 hover:underline">Orders</Link>
-              <Link href="/admin/pos" className="text-slate-700 hover:underline">POS</Link>
-              <Link href="/admin/messages" className="text-slate-700 hover:underline">Messages</Link>
-              <Link href="/admin/settings" className="text-slate-700 hover:underline">Settings</Link>
-            </>
-          ) : (
-            <Link href="/admin/login" className="text-slate-700 hover:underline">Admin</Link>
-          )}
+      <nav className="max-w-5xl mx-auto px-4 sm:px-6 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3 flex-1">
+            <Link href="/" className="flex items-center gap-2 hover:opacity-80">
+              <Image src="/alnoorlogo.png" alt="Al Noor" width={24} height={24} />
+              <span className="font-semibold">Al Noor</span>
+            </Link>
+            <div className="hidden sm:flex items-center gap-3 flex-wrap text-sm">
+              <Link href="/products" className="text-slate-700 hover:underline">
+                Products
+              </Link>
+              <Link href="/contact" className="text-slate-700 hover:underline">
+                Contact
+              </Link>
+              <Link href="/checkout" className="text-slate-700 hover:underline">
+                Checkout
+              </Link>
+              {hasToken ? (
+                <>
+                  <Link href="/admin/dashboard" className="text-slate-700 hover:underline">
+                    Dashboard
+                  </Link>
+                  <Link href="/admin/products" className="text-slate-700 hover:underline">
+                    Admin Products
+                  </Link>
+                  <Link href="/admin/orders" className="text-slate-700 hover:underline">
+                    Orders
+                  </Link>
+                  <Link href="/admin/pos" className="text-slate-700 hover:underline">
+                    POS
+                  </Link>
+                  <Link href="/admin/messages" className="text-slate-700 hover:underline">
+                    Messages
+                  </Link>
+                  <Link href="/admin/settings" className="text-slate-700 hover:underline">
+                    Settings
+                  </Link>
+                </>
+              ) : (
+                <Link href="/admin/login" className="text-slate-700 hover:underline">
+                  Admin
+                </Link>
+              )}
+            </div>
+          </div>
+          <div className="hidden sm:flex items-center gap-4 text-sm">
+            <Link href="/cart" className="inline-flex items-center gap-1 hover:underline">
+              <span>Cart</span>
+              <span className="inline-flex items-center justify-center rounded-full bg-emerald-600 px-2 py-0.5 text-xs font-medium text-white">
+                {count.toFixed(0)}
+              </span>
+            </Link>
+            <div className="text-sm text-slate-600">${total.toFixed(2)}</div>
+            {hasToken && (
+              <button onClick={logout} className="text-slate-600 hover:underline">
+                Logout
+              </button>
+            )}
+          </div>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded border border-slate-300 p-2 text-slate-700 transition sm:hidden"
+            onClick={() => setMenuOpen((open) => !open)}
+            aria-expanded={menuOpen}
+            aria-controls="primary-navigation"
+          >
+            <span className="sr-only">Toggle navigation</span>
+            <svg viewBox="0 0 24 24" aria-hidden="true" className="h-5 w-5">
+              <path
+                d="M4 6h16M4 12h16M4 18h16"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
         </div>
-        <div className="flex items-center gap-4">
-          <Link href="/cart" className="relative hover:underline">
-            Cart
-            <span className="ml-1 inline-flex items-center justify-center text-xs rounded-full bg-emerald-600 text-white px-2 py-0.5">
-              {count.toFixed(0)}
-            </span>
-          </Link>
-          <div className="text-sm text-slate-600 hidden sm:block">${total.toFixed(2)}</div>
-          {hasToken && (
-            <button onClick={logout} className="text-slate-600 hover:underline text-sm">Logout</button>
-          )}
+        <div
+          id="primary-navigation"
+          className={`${menuOpen ? "grid" : "hidden"} sm:hidden mt-3 gap-3 border-t border-slate-200 pt-3 text-sm`}
+        >
+          <div className="grid gap-2">
+            <Link href="/products" className="text-slate-700 hover:underline" onClick={() => setMenuOpen(false)}>
+              Products
+            </Link>
+            <Link href="/contact" className="text-slate-700 hover:underline" onClick={() => setMenuOpen(false)}>
+              Contact
+            </Link>
+            <Link href="/checkout" className="text-slate-700 hover:underline" onClick={() => setMenuOpen(false)}>
+              Checkout
+            </Link>
+            {hasToken ? (
+              <>
+                <Link href="/admin/dashboard" className="text-slate-700 hover:underline" onClick={() => setMenuOpen(false)}>
+                  Dashboard
+                </Link>
+                <Link href="/admin/products" className="text-slate-700 hover:underline" onClick={() => setMenuOpen(false)}>
+                  Admin Products
+                </Link>
+                <Link href="/admin/orders" className="text-slate-700 hover:underline" onClick={() => setMenuOpen(false)}>
+                  Orders
+                </Link>
+                <Link href="/admin/pos" className="text-slate-700 hover:underline" onClick={() => setMenuOpen(false)}>
+                  POS
+                </Link>
+                <Link href="/admin/messages" className="text-slate-700 hover:underline" onClick={() => setMenuOpen(false)}>
+                  Messages
+                </Link>
+                <Link href="/admin/settings" className="text-slate-700 hover:underline" onClick={() => setMenuOpen(false)}>
+                  Settings
+                </Link>
+              </>
+            ) : (
+              <Link href="/admin/login" className="text-slate-700 hover:underline" onClick={() => setMenuOpen(false)}>
+                Admin
+              </Link>
+            )}
+          </div>
+          <div className="grid gap-2">
+            <Link
+              href="/cart"
+              className="inline-flex items-center gap-2 rounded border border-slate-200 px-3 py-2 hover:bg-slate-50"
+              onClick={() => setMenuOpen(false)}
+            >
+              <span>Cart</span>
+              <span className="inline-flex items-center justify-center rounded-full bg-emerald-600 px-2 py-0.5 text-xs font-medium text-white">
+                {count.toFixed(0)}
+              </span>
+            </Link>
+            <div className="text-sm text-slate-600">Total: ${total.toFixed(2)}</div>
+            {hasToken && (
+              <button
+                onClick={() => {
+                  setMenuOpen(false);
+                  void logout();
+                }}
+                className="text-left text-slate-600 hover:underline"
+              >
+                Logout
+              </button>
+            )}
+          </div>
         </div>
       </nav>
       <ApiStatus />

--- a/frontend/components/contact/ContactForm.tsx
+++ b/frontend/components/contact/ContactForm.tsx
@@ -50,7 +50,7 @@ export default function ContactForm() {
         <label className="block text-sm text-slate-600" htmlFor="cmsg">Message</label>
         <textarea id="cmsg" className="border rounded px-2 py-1 w-full" rows={4} value={message} onChange={(e)=> setMessage(e.target.value)} placeholder="How can we help?" required />
       </div>
-      <button type="submit" className="bg-emerald-600 text-white px-3 py-1 rounded hover:bg-emerald-700 disabled:opacity-60" disabled={loading} aria-busy={loading}>
+      <button type="submit" className="w-full rounded bg-emerald-600 px-3 py-1 text-white hover:bg-emerald-700 disabled:opacity-60 sm:w-auto" disabled={loading} aria-busy={loading}>
         {loading ? "Sending..." : "Send"}
       </button>
       {status && (<div className="text-sm text-slate-700">{status}</div>)}

--- a/frontend/components/payments/SquareCard.tsx
+++ b/frontend/components/payments/SquareCard.tsx
@@ -84,7 +84,7 @@ export default function SquareCard({ amountCents, onToken, disabled }: Props) {
         type="button"
         onClick={onPay}
         disabled={!ready || disabled}
-        className="bg-emerald-600 text-white px-3 py-1 rounded hover:bg-emerald-700 disabled:opacity-60"
+        className="w-full rounded bg-emerald-600 px-3 py-1 text-white hover:bg-emerald-700 disabled:opacity-60 sm:w-auto"
       >
         Pay ${amount}
       </button>


### PR DESCRIPTION
## Summary
- add a collapsible mobile navigation and tighten global spacing for small viewports
- reflow storefront forms and detail views so inputs, buttons, and images adapt cleanly on phones
- update admin dashboards, lists, and POS controls to wrap responsively and adjust Jest nav expectations

## Testing
- NODE_ENV=test npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c8a5988a688327a983267459e3db54