### PR TITLE
feat: add contact details to footer and contact page

### DIFF
--- a/frontend/__tests__/footer.test.tsx
+++ b/frontend/__tests__/footer.test.tsx
@@ -2,12 +2,22 @@ import { render, screen } from '@testing-library/react';
 import Footer from '../components/Footer';
 
 describe('Footer', () => {
-  it('shows year, phone, and links', () => {
+  it('shows contact details and navigation links', () => {
     render(<Footer />);
     expect(screen.getByText(/© \d{4} Al Noor Farm/)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Store' })).toHaveAttribute('href', '/products');
     expect(screen.getByRole('link', { name: 'Admin' })).toHaveAttribute('href', '/admin/login');
-    expect(screen.getByRole('link', { name: /Call 716-524-1717/ })).toHaveAttribute('href', 'tel:+17165241717');
+    expect(screen.getByRole('link', { name: 'Facebook' })).toHaveAttribute(
+      'href',
+      'https://www.facebook.com/profile.php?id=100093040494987',
+    );
+    expect(screen.getByRole('link', { name: 'View on Google Maps' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '716-524-1717' })).toHaveAttribute('href', 'tel:+17165241717');
+    expect(screen.getByRole('link', { name: 'info@alnoorfarm716.com' })).toHaveAttribute(
+      'href',
+      'mailto:info@alnoorfarm716.com',
+    );
+    expect(screen.getByText('Hours: Mon-Sat 9:00am-6:00pm')).toBeInTheDocument();
+    expect(screen.getByTitle('Al Noor Farm Location')).toBeInTheDocument();
   });
 });
-

--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -6,7 +6,13 @@ export const metadata = {
 
 export default function ContactPage() {
   const address = "4028 Dickersonville Rd, Ransomville NY 14131";
-  const mapSrc = `https://www.google.com/maps?q=${encodeURIComponent(address)}&output=embed`;
+  const email = "info@alnoorfarm716.com";
+  const phone = "716-524-1717";
+  const phoneHref = "tel:+17165241717";
+  const whatsappLink = "https://wa.me/17165241717";
+  const hours = "Mon-Sat 9:00am-6:00pm";
+  const googleMapsLink = `https://maps.google.com/?q=${encodeURIComponent(address)}`;
+  const mapSrc = `${googleMapsLink}&output=embed`;
   return (
     <section className="grid gap-6">
       <h1 className="text-2xl font-semibold">Contact</h1>
@@ -19,7 +25,17 @@ export default function ContactPage() {
             name: 'Al Noor Farm',
             url: process.env.NEXT_PUBLIC_SITE_URL || undefined,
             address: address,
-            contactPoint: [{ '@type': 'ContactPoint', telephone: '+17165241717', contactType: 'customer service' }],
+            contactPoint: [
+              {
+                '@type': 'ContactPoint',
+                telephone: '+17165241717',
+                contactType: 'customer service',
+                email,
+                areaServed: 'US',
+                availableLanguage: ['English'],
+              },
+            ],
+            openingHours: ['Mo-Sa 09:00-18:00'],
           }),
         }}
       />
@@ -38,18 +54,54 @@ export default function ContactPage() {
           <div className="border rounded p-4">
             <h2 className="font-medium mb-2">Address</h2>
             <p className="text-slate-700">{address}</p>
-            <a className="text-blue-700 hover:underline text-sm" href={`https://maps.google.com/?q=${encodeURIComponent(address)}`} target="_blank" rel="noopener">Open in Google Maps</a>
+            <a
+              className="text-blue-700 hover:underline text-sm"
+              href={googleMapsLink}
+              target="_blank"
+              rel="noopener"
+            >
+              Open in Google Maps
+            </a>
           </div>
           <div className="border rounded p-4">
             <h2 className="font-medium mb-2">Phone</h2>
             <p className="text-slate-700">
-              <a className="hover:underline" href="tel:+17165241717">716-524-1717</a> (calls) •
-              <a className="hover:underline ml-1" href="https://wa.me/17165241717" target="_blank" rel="noopener">WhatsApp</a>
+              <a className="hover:underline" href={phoneHref}>
+                {phone}
+              </a>{' '}
+              (calls) •
+              <a
+                className="hover:underline ml-1"
+                href={whatsappLink}
+                target="_blank"
+                rel="noopener"
+              >
+                WhatsApp
+              </a>
             </p>
           </div>
           <div className="border rounded p-4">
+            <h2 className="font-medium mb-2">Email</h2>
+            <p className="text-slate-700">
+              <a className="hover:underline" href={`mailto:${email}`}>
+                {email}
+              </a>
+            </p>
+          </div>
+          <div className="border rounded p-4">
+            <h2 className="font-medium mb-2">Hours</h2>
+            <p className="text-slate-700">{hours}</p>
+          </div>
+          <div className="border rounded p-4">
             <h2 className="font-medium mb-2">Facebook</h2>
-            <a className="text-blue-700 hover:underline" href="https://www.facebook.com/profile.php?id=100093040494987" target="_blank" rel="noopener">Follow us on Facebook</a>
+            <a
+              className="text-blue-700 hover:underline"
+              href="https://www.facebook.com/profile.php?id=100093040494987"
+              target="_blank"
+              rel="noopener"
+            >
+              Follow us on Facebook
+            </a>
           </div>
         </div>
       </div>

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,18 +1,86 @@
+const address = "4028 Dickersonville Rd, Ransomville NY 14131";
+const email = "info@alnoorfarm716.com";
+const hours = "Mon-Sat 9:00am-6:00pm";
+const mapSrc = `https://www.google.com/maps?q=${encodeURIComponent(address)}&output=embed`;
+const footerInnerClasses = [
+  "max-w-5xl mx-auto px-6 py-4",
+  "text-sm text-slate-600 flex flex-col gap-2",
+  "sm:flex-row sm:items-center sm:justify-between",
+].join(" ");
+
 export default function Footer() {
   return (
-    <footer className="border-t mt-8">
-      <div className="max-w-5xl mx-auto px-6 py-6 text-sm text-slate-600 grid gap-2 sm:flex sm:items-center sm:justify-between">
-        <div>© {new Date().getFullYear()} Al Noor Farm</div>
-        <div className="flex items-center gap-3 flex-wrap">
-          <a className="hover:underline" href="/products">Store</a>
-          <span className="hidden sm:inline">•</span>
-          <a className="hover:underline" href="/admin/login">Admin</a>
-          <span className="hidden sm:inline">•</span>
-          <a className="hover:underline" href="tel:+17165241717">Call 716-524-1717</a>
-          <span className="hidden sm:inline">•</span>
-          <a className="hover:underline" href="https://wa.me/17165241717" target="_blank" rel="noopener">WhatsApp</a>
-          <span className="hidden sm:inline">•</span>
-          <a className="hover:underline" href="https://www.facebook.com/profile.php?id=100093040494987" target="_blank" rel="noopener">Facebook</a>
+    <footer className="border-t mt-8 bg-slate-50">
+      <div className="max-w-5xl mx-auto px-6 py-8 grid gap-6 lg:grid-cols-[1.1fr_minmax(0,1fr)]">
+        <div className="space-y-4 text-sm text-slate-600">
+          <div>
+            <h2 className="text-base font-semibold text-slate-800">Visit Al Noor Farm</h2>
+            <p className="mt-1 leading-relaxed">
+              <span className="block">{address}</span>
+              <a
+                className="text-emerald-700 hover:underline"
+                href={`https://maps.google.com/?q=${encodeURIComponent(address)}`}
+                target="_blank"
+                rel="noopener"
+              >
+                View on Google Maps
+              </a>
+            </p>
+          </div>
+          <div className="leading-relaxed">
+            <p>
+              Phone:{" "}
+              <a className="hover:underline" href="tel:+17165241717">
+                716-524-1717
+              </a>
+              {" "}(calls)
+            </p>
+            <p>
+              <a
+                className="hover:underline"
+                href="https://wa.me/17165241717"
+                target="_blank"
+                rel="noopener"
+              >
+                WhatsApp chat
+              </a>
+            </p>
+            <p>
+              Email:{" "}
+              <a className="hover:underline" href={`mailto:${email}`}>
+                {email}
+              </a>
+            </p>
+          </div>
+          <p className="leading-relaxed">Hours: {hours}</p>
+        </div>
+        <div className="border rounded overflow-hidden h-48">
+          <iframe
+            title="Al Noor Farm Location"
+            src={mapSrc}
+            className="h-full w-full"
+            loading="lazy"
+            referrerPolicy="no-referrer-when-downgrade"
+          />
+        </div>
+      </div>
+      <div className="border-t bg-white">
+        <div className={footerInnerClasses}>
+          <div>© {new Date().getFullYear()} Al Noor Farm</div>
+          <div className="flex items-center gap-3 flex-wrap">
+            <a className="hover:underline" href="/products">Store</a>
+            <span className="hidden sm:inline">•</span>
+            <a className="hover:underline" href="/admin/login">Admin</a>
+            <span className="hidden sm:inline">•</span>
+            <a
+              className="hover:underline"
+              href="https://www.facebook.com/profile.php?id=100093040494987"
+              target="_blank"
+              rel="noopener"
+            >
+              Facebook
+            </a>
+          </div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- expand the footer with full contact information, business hours, and a map embed
- enrich the contact page with email, hours, structured data, and updated contact cards
- update the footer test to cover the new links and embedded map

## Testing
- NODE_ENV=test npm test -- --runTestsByPath __tests__/footer.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c8a5a083088327b9f08104828be376