### PR TITLE
Parameterize landing page base path configuration

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -58,6 +58,7 @@ This guide walks through preparing and launching the Al Noor Farm frontend (Next
 - The Next.js application expects to live under `/alnoor`; update `NEXT_PUBLIC_BASE_PATH` and web server rewrites accordingly.
 - Reserve a path such as `/api` (or another prefix) for the FastAPI backend and configure your reverse proxy or .htaccess rules to forward requests there.
 - Static links on the landing page redirect `/store`, `/admin`, and `/pos` into the `/alnoor` Next.js app.
+- When the storefront base path changes, run `python scripts/build_redirect_page.py` to regenerate `index.html` and refresh the static landing links.
 
 Keep the deployment scripts and environment variable definitions in sync with any future backend database or authentication changes.
 

--- a/scripts/build_redirect_page.py
+++ b/scripts/build_redirect_page.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Render the redirect landing page and update static links for the configured base path."""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from string import Template
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_PATH = REPO_ROOT / "templates" / "root-redirect.html"
+OUTPUT_PATH = REPO_ROOT / "index.html"
+PUBLIC_LANDING_PATH = REPO_ROOT / "public" / "index.html"
+
+
+def normalise_base_path(raw: str | None) -> str:
+    """Ensure the base path starts with a slash and has no trailing slash."""
+    if raw is None:
+        return "/alnoor"
+    cleaned = raw.strip()
+    if not cleaned:
+        return "/alnoor"
+    if not cleaned.startswith("/"):
+        cleaned = f"/{cleaned}"
+    if len(cleaned) > 1 and cleaned.endswith("/"):
+        cleaned = cleaned.rstrip("/")
+    return cleaned or "/"
+
+
+def base_with_trailing_slash(base_path: str) -> str:
+    """Return the base path with a trailing slash (except for root)."""
+    if base_path == "/":
+        return "/"
+    return f"{base_path}/"
+
+
+def render_redirect_page(base_path: str) -> str:
+    template = Template(TEMPLATE_PATH.read_text(encoding="utf-8"))
+    prefix = "" if base_path == "/" else base_path
+    redirect_target = base_with_trailing_slash(base_path)
+    substitutions = {
+        "redirect_target": redirect_target,
+        "meta_refresh": f"0; url={redirect_target}",
+        "store_href": f"{prefix}/products",
+        "admin_href": f"{prefix}/admin/login",
+        "pos_href": f"{prefix}/admin/pos",
+    }
+    return template.substitute(substitutions)
+
+
+def update_static_landing_page(base_path: str) -> None:
+    """Rewrite the public landing page links to respect the configured base path."""
+    prefix = "" if base_path == "/" else base_path
+    html = PUBLIC_LANDING_PATH.read_text(encoding="utf-8")
+    html = re.sub(r'data-app-base="[^"]+"', f'data-app-base="{base_path}"', html)
+    html = re.sub(r"\|\|\s*'[^']+'", f"|| '{base_path}'", html)
+
+    def rewrite_slug(source: str, slug: str) -> str:
+        target = f"{prefix}/{slug}" if prefix else f"/{slug}"
+        if not target.startswith('/'):
+            target = '/' + target
+        pattern = re.compile(rf'href="/[^"]*{re.escape(slug)}"')
+        return pattern.sub(f'href="{target}"', source)
+
+    for slug in ("products", "admin/login", "admin/pos"):
+        html = rewrite_slug(html, slug)
+    PUBLIC_LANDING_PATH.write_text(html, encoding="utf-8")
+
+
+def main() -> None:
+    base_env = os.getenv("ALNOOR_BASE_PATH") or os.getenv("NEXT_PUBLIC_BASE_PATH")
+    base_path = normalise_base_path(base_env)
+    OUTPUT_PATH.write_text(render_redirect_page(base_path), encoding="utf-8")
+    update_static_landing_page(base_path)
+    print(f"Wrote {OUTPUT_PATH.relative_to(REPO_ROOT)} for base path '{base_path}'.")
+    print(
+        "Updated public/index.html links to match the configured base path.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/root-redirect.html
+++ b/templates/root-redirect.html
@@ -5,8 +5,8 @@
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <title>Redirecting to Al Noor Farm</title>
         <link rel="icon" type="image/png" href="/assets/alnoorlogo.png" />
-        <meta name="alnoor-target" content="/alnoor/" />
-        <meta http-equiv="refresh" content="0; url=/alnoor/" />
+        <meta name="alnoor-target" content="$redirect_target" />
+        <meta http-equiv="refresh" content="$meta_refresh" />
         <style>
             body {
                 margin: 0;
@@ -57,11 +57,11 @@
             <p>You should be redirected to the updated storefront momentarily.</p>
             <p>If the page does not change, continue with one of the quick links below.</p>
             <p class="links" role="navigation" aria-label="Al Noor destinations">
-                <a data-alnoor-link="/alnoor/products" href="/alnoor/products">Store</a>
+                <a data-alnoor-link="$store_href" href="$store_href">Store</a>
                 <span aria-hidden="true">•</span>
-                <a data-alnoor-link="/alnoor/admin/login" href="/alnoor/admin/login">Admin</a>
+                <a data-alnoor-link="$admin_href" href="$admin_href">Admin</a>
                 <span aria-hidden="true">•</span>
-                <a data-alnoor-link="/alnoor/admin/pos" href="/alnoor/admin/pos">POS</a>
+                <a data-alnoor-link="$pos_href" href="$pos_href">POS</a>
             </p>
         </div>
         <noscript>


### PR DESCRIPTION
## Summary
- add a build script that renders the root redirect and updates the static landing page using the configured base path
- template the redirect HTML so meta refresh and quick links are derived from the resolved environment target
- document the regeneration step in the deployment guide for teams changing the storefront base path

## Testing
- python scripts/build_redirect_page.py
- python -m compileall scripts/build_redirect_page.py

------
https://chatgpt.com/codex/tasks/task_e_68c8b6751a288327bdfc5c3e7fb83cf3