### PR TITLE
fix: import feedback router

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import products, orders, auth, pos, contact, admin, reviews
+from app.routes import products, orders, auth, pos, contact, admin, reviews, feedback
 from app.database import init_db, seed_if_empty
 
 app = FastAPI(title="Al Noor Farm API", version="0.1.0")


### PR DESCRIPTION
## Summary
- include the feedback router in the FastAPI application's route imports so startup succeeds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8bea4de148327a20b8911c0f1fdad