### PR TITLE
fix: avoid redirect loop at root base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
         <title>Redirecting to Al Noor Farm</title>
         <link rel="icon" type="image/png" href="/assets/alnoorlogo.png" />
         <meta name="alnoor-target" content="/" />
-        <meta http-equiv="refresh" content="0; url=/" />
+
         <style>
             body {
                 margin: 0;

--- a/scripts/build_redirect_page.py
+++ b/scripts/build_redirect_page.py
@@ -38,9 +38,15 @@ def render_redirect_page(base_path: str) -> str:
     template = Template(TEMPLATE_PATH.read_text(encoding="utf-8"))
     prefix = "" if base_path == "/" else base_path
     redirect_target = base_with_trailing_slash(base_path)
+    meta_refresh_tag = ""
+    if base_path != "/":
+        meta_refresh_tag = (
+            "        "
+            f'<meta http-equiv="refresh" content="0; url={redirect_target}" />\n'
+        )
     substitutions = {
         "redirect_target": redirect_target,
-        "meta_refresh": f"0; url={redirect_target}",
+        "meta_refresh_tag": meta_refresh_tag,
         "store_href": f"{prefix}/products",
         "admin_href": f"{prefix}/admin/login",
         "pos_href": f"{prefix}/admin/pos",

--- a/templates/root-redirect.html
+++ b/templates/root-redirect.html
@@ -6,7 +6,7 @@
         <title>Redirecting to Al Noor Farm</title>
         <link rel="icon" type="image/png" href="/assets/alnoorlogo.png" />
         <meta name="alnoor-target" content="$redirect_target" />
-        <meta http-equiv="refresh" content="$meta_refresh" />
+$meta_refresh_tag
         <style>
             body {
                 margin: 0;


### PR DESCRIPTION
## Summary
- skip generating a meta refresh when the base path resolves to the site root
- update the template so the meta refresh tag only renders for non-root deployments and regenerate index.html

## Testing
- ALNOOR_BASE_PATH=/ python scripts/build_redirect_page.py

------
https://chatgpt.com/codex/tasks/task_e_68c8ca8e622083279fce531aa1a543fc