### PR TITLE
Fix product media references in products page

### DIFF
--- a/frontend/app/products/page.tsx
+++ b/frontend/app/products/page.tsx
@@ -1,5 +1,6 @@
 import { fetchProducts } from "@/lib/api";
 import { getWeightPricing } from "@/lib/weight";
+import LocalizedText from "@/components/LocalizedText";
 import Link from "next/link";
 
 type Props = { searchParams?: { q?: string } };
@@ -72,6 +73,9 @@ export default async function ProductsPage({ searchParams }: Props) {
             const desc = (p as any).description || "";
             const short = desc.length > 80 ? desc.slice(0, 77) + "..." : desc;
             const weight = getWeightPricing(p);
+            const thumb = (p as any).image_url;
+            const isVideo = false;
+            const mediaUrl = thumb;
             return (
               <li key={p.id} className="border rounded overflow-hidden hover:shadow">
                 <Link href={`/products/${p.id}`} className="block">


### PR DESCRIPTION
## Summary
- import the LocalizedText component on the products page
- define thumbnail and media helper constants when rendering the product list

## Testing
- npm run build *(fails: existing syntax errors in app/admin/products/page.tsx, app/cart/page.tsx, and app/contact/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ccd001fc8327b5787c05c1753664