### PR TITLE
test: import visitor feedback model for fixtures

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,7 +11,7 @@ if str(ROOT) not in sys.path:
 
 from app.main import app
 from app.database import init_db, seed_if_empty, get_session
-from app.models import ContactMessage, Review
+from app.models import ContactMessage, Review, VisitorFeedback
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- update the backend test fixture imports to include the VisitorFeedback model so cleanup works as expected

## Testing
- pytest backend/tests/test_feedback_endpoints.py::test_feedback_submission_and_summary -q *(fails: coverage threshold 80% not met)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d7a3d69c83279e8c9d21c1582f4f