### PR TITLE
Fix product pricing interpolation

### DIFF
--- a/frontend/app/products/page.tsx
+++ b/frontend/app/products/page.tsx
@@ -101,10 +101,10 @@ export default async function ProductsPage({ searchParams }: Props) {
                           <div className="text-slate-600 text-xs">ID: {p.id}</div>
                         </div>
                         <div className="text-right">
-                          <div className="font-semibold">${p.price.toFixed(2)}</div>
+                          <div className="font-semibold">{`$${p.price.toFixed(2)}`}</div>
                           {weight ? (
                             <div className="text-xs text-slate-500">
-                              ${weight.perLb.toFixed(2)}/lb · ${weight.perKg.toFixed(2)}/kg
+                              {`${weight.perLb.toFixed(2)}/lb · ${weight.perKg.toFixed(2)}/kg`}
                             </div>
                           ) : (
                             <div className="text-xs text-slate-500">{(p as any).unit || "unit"}</div>


### PR DESCRIPTION
## Summary
- render product pricing and weight breakdown values using JSX interpolation so they display dynamically

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68c9ddf1091c8327aa9110a19b257633